### PR TITLE
Fix 24bit soundfont bug

### DIFF
--- a/trunk/sf2_core/pile_sf2_sl.cpp
+++ b/trunk/sf2_core/pile_sf2_sl.cpp
@@ -1670,10 +1670,11 @@ int Pile_sf2::sauvegarderSf2(int indexSf2, QString fileName)
             fi.write((char *)&wTmp, 4);
         }
     }
-    // phdr de fin
+    // phdr de fin (38 byte)
     fi.write("EOP", 3);
     charTmp = '\0';
-    fi.write(&charTmp, 21);
+    for (quint32 i = 0; i < 21; i++)
+        fi.write(&charTmp, 1);
     // index bag de fin
     wTmp = nBag;
     fi.write((char *)&wTmp, 2);

--- a/trunk/sf2_core/pile_sf2_sl.cpp
+++ b/trunk/sf2_core/pile_sf2_sl.cpp
@@ -1519,7 +1519,6 @@ int Pile_sf2::sauvegarderSf2(int indexSf2, QString fileName)
     }
 
     // 24 bits
-    dwTmp2 = 11*4 + taille_info + taille_smpl;
     id.typeElement = elementSf2;
     if (this->get(id, champ_wBpsSave).wValue == 24)
     {
@@ -1527,6 +1526,7 @@ int Pile_sf2::sauvegarderSf2(int indexSf2, QString fileName)
         fi.write("sm24", 4);
         taille_sm24 -= 8;
         fi.write((char *)&taille_sm24, 4);
+        dwTmp2 = 12*4 + taille_info + taille_smpl;
         for (int i = 0; i < this->count(id2); i++)
         {
             // copie de chaque sample

--- a/trunk/sf2_core/sound.cpp
+++ b/trunk/sf2_core/sound.cpp
@@ -176,7 +176,7 @@ QByteArray Sound::getData(quint16 wBps)
             baRet.resize(_info.dwLength*3);
             char * cDest = baRet.data();
             char * cFrom = this->_smpl.data();
-            char * cFrom24 = this->_smpl.data();
+            char * cFrom24 = this->_sm24.data();
             int len = (int)_info.dwLength;
             for (int i = 0; i < len; i++)
             {
@@ -249,7 +249,7 @@ QByteArray Sound::getData(quint16 wBps)
             baRet.resize(_info.dwLength*4);
             char * cDest = baRet.data();
             char * cFrom = this->_smpl.data();
-            char * cFrom24 = this->_smpl.data();
+            char * cFrom24 = this->_sm24.data();
             int len = (int)_info.dwLength;
             for (int i = 0; i < len; i++)
             {


### PR DESCRIPTION
Fix bugs related to 24bit sound font file:
1. Load a sound font file that contains 24bit data.
2. Export the sound font in sfz format.
3. Save the sound font file.
4. Export the sound font in sfz format.
5. Compare the wave files in the exported folder.
The waves are different (This is the bug, caused by a corruption of champ_dwStart24 in save sound font function).

Fix preset header EOP bug: 
1. Load a sound font file. 
2. Save the sound font file.
3. Compare the sound font file.
The sound font saved and the original are different (This is a bug, caused by a wrong use of write function in the EOP preset header).

Fix other 24bit bugs in sound.cpp file.