### PR TITLE
config.ccp: include QAction explicitly to fix build with Qt 5.11

### DIFF
--- a/trunk/configuration/config.cpp
+++ b/trunk/configuration/config.cpp
@@ -26,6 +26,7 @@
 #include <QDir>
 #include <QColorDialog>
 #include <QDesktopServices>
+#include <QAction>
 #include "config.h"
 #include "ui_config.h"
 #include "mainwindow.h"


### PR DESCRIPTION
Fixes many errors like:
| ../git/trunk/configuration/config.cpp:363:55: error: invalid use of incomplete type 'class QAction'
|              ui->listActions->addItem(_actionList.at(i)->text().replace("&", ""));
|                                                        ^~
| In file included from ../recipe-sysroot/usr/include/qt5/QtWidgets/qdialog.h:44:0,
|                  from ../recipe-sysroot/usr/include/qt5/QtWidgets/qcolordialog.h:45,
|                  from ../recipe-sysroot/usr/include/qt5/QtWidgets/QColorDialog:1,
|                  from ../git/trunk/configuration/config.cpp:27:

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>