### PR TITLE
Adding distribution agnostic integration files (man pages, XDG desktop)

### DIFF
--- a/sources/contrib/polyphone.1
+++ b/sources/contrib/polyphone.1
@@ -1,0 +1,106 @@
+.TH POLYPHONE "1" "November 7th, 2018" "polyphone 2.0" "Polyphone Manual Page"
+
+.SH NAME
+\fBpolyphone\fP \- soundfont editor
+
+.SH SYNOPSIS
+.B polyphone
+.br
+.B polyphone
+[\fIFILE\fR]
+.br
+.B polyphone
+[\fIFILE_1\fR] [\fIFILE_2\fR] ...
+.br
+.B polyphone
+-1 [\fB\-i\fR \fIINPUT_FILEPATH\fR] [\fB\-d\fR \fIOUTPUT_DIR\fR] [\fB\-o\fR \fIOUTPUT_NAME\fR]
+.br
+.B polyphone
+-2 [\fB\-i\fR \fIINPUT_FILEPATH\fR] [\fB\-d\fR \fIOUTPUT_DIR\fR] [\fB\-o\fR \fIOUTPUT_NAME\fR] [\fB\-c\fR \fICONFIG\fR]
+.br
+.B polyphone
+-3 [\fB\-i\fR \fIINPUT_FILEPATH\fR] [\fB\-d\fR \fIOUTPUT_DIR\fR] [\fB\-o\fR \fIOUTPUT_NAME\fR] [\fB\-c\fR \fICONFIG\fR]
+
+.SH DESCRIPTION
+.B polyphone
+provides a simple and efficient interface for creating and editing .sf2 files. This software comprises tools to facilitate and automate the editing of different parameters, making it possible to handle a large amount of data.
+.br
+.PP
+sf2, sf3, sfz (import / export) and sfArk (import only) formats are supported. Conversions are possible via command lines.
+.br
+.PP
+More information can be found at https://www.polyphone-soundfonts.com .
+
+.SH OPTIONS
+.TP
+.BR \fBFILE\fR
+Specifies the file to open when
+.B polyphone
+starts. Multiple files can be loaded if they are separated by spaces.
+sf2 (version 2.01 or 2.04), sf3, sfz and sfArk (version 1 or 2) formats are supported.
+.TP
+.BR \fB-1\fR
+Use
+.B polyphone
+to convert a file into the sf2 format.
+.TP
+.BR \fB-2\fR
+Use
+.B polyphone
+to convert a file into the sf3 format.
+.TP
+.BR \fB-3\fR
+Use
+.B polyphone
+to convert a file into the sfz format.
+.TP
+[\fB\-i\fR \fIINPUT_FILEPATH\fR]
+Input path to convert. The input file format must be sf2, sf3, sfz or sfArk.
+.TP
+[\fB\-d\fR \fIOUTPUT_DIR\fR]
+Output directory in which the input file will be converted. By default, this is the same directory than the input file.
+.TP
+[\fB\-o\fR \fIOUTPUT_NAME\fR]
+Output name of the converted file. The extension will be automatically added depending on the conversion. By default, this is the same name than the input file.
+.TP
+[\fB\-c\fR \fICONFIG\fR]
+Conversion configuration, the content being dependent on the conversion type.
+.BR \fB-r\fR
+Remove the existing configuration.
+.br
+.BR
+ * 
+.B sf2 conversion
+.br
+No configuration for this conversion.
+.br
+.BR
+ * 
+.B sf3 conversion
+.br
+The configuration is made of one character indicating the compression quality. '0' for low, '1' for medium and '2' for high quality. Default is '1'.
+.br
+.BR
+ * 
+.B sfz conversion
+.br
+The configuration is made of three characters. The first character is '1' if each preset must be prefixed by its preset number, '0' otherwise. The second character is '1' if a directory per bank must be created, '0' otherwise. The third character is '1' if the general midi classification must be used to sort presets, '0' otherwise. Default is '000'.
+.SH EXAMPLES
+ * Conversion from sfArk to sf2:
+.br
+.BR polyphone
+-1 -i /path/to/file.sfArk
+.br
+.BR
+ * Conversion from sf2 to sf3 (good quality):
+.br
+.BR polyphone
+-2 -i /path/to/file.sf2 -c 2
+.br
+.BR
+ * Conversion from sf3 to sfz (sub-directories for bank and gm classification):
+.br
+.BR polyphone
+-3 -i /path/to/file.sf3 -c 011
+.SH AUTHOR
+Davy Triponney (davy.triponney@gmail.com)

--- a/sources/contrib/polyphone.desktop
+++ b/sources/contrib/polyphone.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Name=Polyphone
+Name[sr]=Полифон
+Name[ru]=Полифон
+Comment=soundfont editor
+Comment[en]=Soundfont editor
+Comment[es]=Editor de soundfonts
+Comment[fr]=Éditeur de banques de son
+Comment[it]=Editore de soundfonts
+Comment[sr]=Уређивач звукотека (звучних фонтова)
+TryExec=polyphone
+Exec=polyphone %F
+Icon=polyphone
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=Application;AudioVideo;Audio;Midi;Music;
+Keywords=sf2;sf3;sfz;sfArk;soundfonts;editor;instrument;audio;sound;sampler;
+MimeType=audio/x-soundfont;

--- a/sources/contrib/polyphone.fr.1
+++ b/sources/contrib/polyphone.fr.1
@@ -1,0 +1,108 @@
+.TH POLYPHONE "1" "7 novembre 2018" "polyphone 2.0" "Page de manuel pour Polyphone"
+
+.SH NOM
+\fBpolyphone\fP \- éditeur de banque de sons
+
+.SH SYNOPSIS
+.B polyphone
+.br
+.B polyphone
+[\fIFICHIER\fR]
+.br
+.B polyphone
+[\fIFICHIER_1\fR] [\fIFICHIER_2\fR] ...
+.br
+.B polyphone
+-1 [\fB\-i\fR \fICHEMIN_DE_FICHIER_EN_ENTRÉE\fR] [\fB\-d\fR \fIRÉPERTOIRE_EN_SORTIE\fR] [\fB\-o\fR \fINOM_EN_SORTIE\fR]
+.br
+.B polyphone
+-2 [\fB\-i\fR \fICHEMIN_DE_FICHIER_EN_ENTRÉE\fR] [\fB\-d\fR \fIRÉPERTOIRE_EN_SORTIE\fR] [\fB\-o\fR \fINOM_EN_SORTIE\fR] [\fB\-c\fR \fICONFIG\fR]
+.br
+.B polyphone
+-3 [\fB\-i\fR \fICHEMIN_DE_FICHIER_EN_ENTRÉE\fR] [\fB\-d\fR \fIRÉPERTOIRE_EN_SORTIE\fR] [\fB\-o\fR \fINOM_EN_SORTIE\fR] [\fB\-c\fR \fICONFIG\fR]
+
+.SH DESCRIPTION
+.B polyphone
+fournit une interface simple et efficace pour créer et éditer des fichiers .sf2 . Ce logiciel incorpore des outils pour faciliter et automatiser l'édition de différents paramètres, rendant possible de gérer de grandes quantités de données. 
+.br
+.PP
+Les formats sf2, sf3, sfz (import / export) et sfArk (import uniquement) sont supportés. Les conversions sont possibles en ligne de commande.
+.br
+.PP
+Davantage d'informations peuvent être trouvées à https://www.polyphone-soundfonts.com .
+
+.SH OPTIONS
+.TP
+.BR \fBFICHIER\fR
+Spécifie le fichier à ouvrir quand
+.B polyphone
+démarre. Plusieurs fichiers peuvent être chargés s'ils sont séparés par des espaces.
+Les formats sf2 (version 2.01 ou 2.04), sf3, sfz et sfArk (version 1 ou 2) sont supportés.
+.TP
+.BR \fB-1\fR
+Utilisez
+.B polyphone
+pour convertir un fichier dans le format sf2.
+.TP
+.BR \fB-2\fR
+Utilisez
+.B polyphone
+pour convertir un fichier dans le format sf3.
+.TP
+.BR \fB-3\fR
+Utilisez
+.B polyphone
+pour convertir un fichier dans le format sfz.
+.TP
+[\fB\-i\fR \fICHEMIN_DU_FICHIER_EN_ENTRÉE\fR]
+Chemin d'entrée à convertir. Le format du fichier d'entrée doit être sf2, sf3, sfz ou sfArk.
+.TP
+[\fB\-d\fR \fIRÉPERTOIRE_DE_SORTIE\fR]
+Le répertoire de sortie dans lequel le fichier d'entrée sera converti. Par défaut, c'est le même répertoire que celui du fichier d'entrée.
+.TP
+[\fB\-o\fR \fINOM_DE_SORTIE\fR]
+Le nom de sortie du fichier converti. L'extension sera ajoutée automatiquement suivant la conversion. Par défaut, c'est le même nom que le fichier d'entrée.
+.TP
+[\fB\-c\fR \fICONFIG\fR]
+Configuration de la conversion, le contenu étant dépendant du type de conversion.
+.BR \fB-r\fR
+Supprime la configuration existante.
+.br
+.BR
+ * 
+.B conversion sf2
+.br
+Pas de configuration pour cette conversion.
+.br
+.BR
+ * 
+.B conversion sf3
+.br
+La configuration est faite avec un caractère indiquant la qualité de la compression. '0' pour basse, '1' pour moyenne, et '2' pour haute qualité. Le défaut est de '1'.
+.br
+.BR
+ * 
+.B conversion sfz
+.br
+La configuration est faite de trois caractères. Le premier caractère est '1' si chaque pré-réglage doit être préfixé par son numéro de pré-réglage, '0' sinon. Le deuxième caractère est '1' si un répertoire par banque doit être créé, '0' sinon. Le troisième caractère est '1' si la classification General MIDI doit être utilisée pour trier les pré-réglages, '0' sinon. Par défaut, c'est '000'.
+.SH EXEMPLES
+ * Conversion depuis sfArk vers sf2 :
+.br
+.BR polyphone
+-1 -i /chemin/vers/le/fichier.sfArk
+.br
+.BR
+ * Conversion depuis sf2 vers sf3 (bonne qualité) :
+.br
+.BR polyphone
+-2 -i /chemin/vers/le/fichier.sf2 -c 2
+.br
+.BR
+ * Conversion depuis sf3 vers sfz (sous-répertoire pour la banque et classification GM) :
+.br
+.BR polyphone
+-3 -i /chemin/vers/le/fichier.sf3 -c 011
+.SH AUTEUR
+Davy Triponney (davy.triponney@gmail.com)
+.br
+Cette page de manuel a été traduite (à partir de la version version anglaise fournie par l'amont) par Olivier Humbert (<trebmuh@tuxfamily.org>) pour le projet LibraZiK et peut être utilisée par tout le monde.

--- a/sources/contrib/polyphone.xml
+++ b/sources/contrib/polyphone.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="audio/x-soundfont">
+    <comment>SoundFont sf2</comment>
+    <magic priority="50">
+      <match type="string" offset="0" value="RIFF">
+        <match type="string" offset="8" value="sfbk"/>
+      </match>
+    </magic>
+    <glob pattern="*.sf2"/>
+  </mime-type>
+  <mime-type type="audio/x-soundfont">
+    <comment>SoundFont sfz</comment>
+    <glob pattern="*.sfz"/>
+  </mime-type>
+  <mime-type type="audio/x-soundfont">
+    <comment>Compressed SoundFont sf3</comment>
+    <glob pattern="*.sf3"/>
+  </mime-type>
+  <mime-type type="audio/x-soundfont">
+    <comment>SoundFont archive sfArk</comment>
+    <glob pattern="*.sfArk"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
This fixes #78.
sources/contrib/polyphone.*: Adding distribution agnostic files (man pages, XDG desktop and mime info).