### PR TITLE
fix linux build - correctly include jack header (at least openSUSE pk…

### DIFF
--- a/sources/context/audiodevice.cpp
+++ b/sources/context/audiodevice.cpp
@@ -29,7 +29,7 @@
 #include "contextmanager.h"
 
 #ifndef Q_OS_WIN
-#include "jack.h"
+#include "jack/jack.h"
 
 // Callbacks de jack
 int jackProcess(jack_nframes_t nframes, void * arg)


### PR DESCRIPTION
…g-config --cflags jack doesn't provide proper -I include path)