### PR TITLE
Apply plural forms.

### DIFF
--- a/sources/context/translationmanager.cpp
+++ b/sources/context/translationmanager.cpp
@@ -77,18 +77,14 @@ void TranslationManager::translate()
                 ConfManager::SECTION_NONE, "language",
                 QLocale::system().name().section('_', 0, 0)).toString();
 
-    // If not english, the application is translated
-    if (language != "en")
-    {
-        if (!_languages.keys().contains(language))
-            language = DEFAULT_LANGUAGE;
+    if (!_languages.keys().contains(language))
+        language = DEFAULT_LANGUAGE;
 
-        // First try to find an additional file
-        QString fileName = "/polyphone_" + language + ".qm";
-        if (QFile::exists(QDir::currentPath() + "/" + TRANSLATION_DIRECTORY + fileName))
-            _translator->load(QDir::currentPath() + "/" + TRANSLATION_DIRECTORY + fileName);
-        else
-            _translator->load(RESOURCE_PATH + fileName);
-        QApplication::installTranslator(_translator);
-    }
+    // First try to find an additional file
+    QString fileName = "/polyphone_" + language + ".qm";
+    if (QFile::exists(QDir::currentPath() + "/" + TRANSLATION_DIRECTORY + fileName))
+        _translator->load(QDir::currentPath() + "/" + TRANSLATION_DIRECTORY + fileName);
+    else
+        _translator->load(RESOURCE_PATH + fileName);
+    QApplication::installTranslator(_translator);
 }

--- a/sources/editor/modulator/modulatoreditor.cpp
+++ b/sources/editor/modulator/modulatoreditor.cpp
@@ -251,12 +251,7 @@ void ModulatorEditor::updateInterface(QList<AttributeType> attributes, bool keep
     }
     else
     {
-        summary = "<b>";
-        if (modCount == 1)
-            summary += tr("1 modulator:", "singular form of modulator");
-        else
-            summary += tr("%1 modulators:", "plural form of modulator").arg(modCount);
-        summary += "</b> ";
+        summary = "<b>" + tr("%n modulator(s):", "", modCount) + "</b> ";
         for (int i = 0; i < modTargets.count(); i++)
             summary += (i > 0 ? ", " : "") + modTargets[i];
         ui->labelModSummary->setStyleSheet("");

--- a/sources/editor/overview/pageoverview.cpp
+++ b/sources/editor/overview/pageoverview.cpp
@@ -80,7 +80,7 @@ bool PageOverview::updateInterface(QString editingSource, IdList selectedIds, in
     id.typeElement = _typeElement;
     QList<int> indexes = _sf2->getSiblings(id);
     ui->table->setRowCount(indexes.count());
-    ui->labelInformation->setText(QString::number(indexes.count()) + " " + (indexes.count() > 1 ? tr("elements") : tr("element")));
+    ui->labelInformation->setText(tr("%n element(s)", "", indexes.count()));
 
     // Preparation (if needed by the overview page)
     this->prepare(id);

--- a/sources/editor/pagesf2.cpp
+++ b/sources/editor/pagesf2.cpp
@@ -244,10 +244,7 @@ void PageSf2::countElements()
     // Display
     if (unusedSmpl)
     {
-        if (unusedSmpl > 1)
-            ui->label_nbSmpl->setText(tr("%1 (unused: %2)", "plural form").arg(usedSmpl).arg(unusedSmpl));
-        else
-            ui->label_nbSmpl->setText(tr("%1 (unused: %2)", "singular form").arg(usedSmpl).arg(unusedSmpl));
+        ui->label_nbSmpl->setText(tr("%1 (unused: %n)", "", unusedSmpl).arg(usedSmpl));
         ui->label_nbSmpl->setStyleSheet(redStr);
     }
     else
@@ -257,10 +254,7 @@ void PageSf2::countElements()
     }
     if (unusedInst)
     {
-        if (unusedInst > 1)
-            ui->label_nbInst->setText(tr("%1 (unused: %2)", "plural form").arg(usedInst).arg(unusedInst));
-        else
-            ui->label_nbInst->setText(tr("%1 (unused: %2)", "singular form").arg(usedInst).arg(unusedInst));
+        ui->label_nbInst->setText(tr("%1 (unused: %n)", "", unusedInst).arg(usedInst));
         ui->label_nbInst->setStyleSheet(redStr);
     }
     else

--- a/sources/editor/tools/clean_unused_elements/toolcleanunused.cpp
+++ b/sources/editor/tools/clean_unused_elements/toolcleanunused.cpp
@@ -107,5 +107,7 @@ void ToolCleanUnused::process(SoundfontManager * sm, EltID id, AbstractToolParam
 
 QString ToolCleanUnused::getConfirmation()
 {
-    return tr("%1 sample(s) and %2 instrument(s) have been deleted.").arg(_unusedSmpl).arg(_unusedInst);
+    return tr("%1 and %2 have been deleted.", "[X sample(s)] and [Y instrument(s)] have been deleted.").
+           arg(tr("%n sample(s)",     "", _unusedSmpl)).
+           arg(tr("%n instrument(s)", "", _unusedInst));
 }

--- a/sources/editor/tools/remove_mods/toolremovemods.cpp
+++ b/sources/editor/tools/remove_mods/toolremovemods.cpp
@@ -112,11 +112,10 @@ void ToolRemoveMods::clearMod(SoundfontManager * sm, EltID idMod)
 
 QString ToolRemoveMods::getConfirmation()
 {
-    if (_count == 1)
-        return tr("1 modulator has been deleted.");
-    else if (_count > 1)
-        return tr("%1 modulators have been deleted.").arg(QString::number(_count));
-    return "";
+    if (_count == 0)
+        return "";
+    else
+        return tr("%n modulator(s) has(have) been deleted.", "", _count);
 }
 
 QString ToolRemoveMods::getWarning()

--- a/sources/polyphone_cs.ts
+++ b/sources/polyphone_cs.ts
@@ -2665,17 +2665,14 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 modulátor:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 modulátory:</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n modulátor:</numerusform>
+            <numerusform>%n modulátory:</numerusform>
+            <numerusform>%n modulátorů:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2805,15 +2802,14 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>Prvky</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>Prvek</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n prvek</numerusform>
+            <numerusform>%n prvky</numerusform>
+            <numerusform>%n prvků</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3231,19 +3227,15 @@ rate</source>
         <comment>kilo byte</comment>
         <translation>kB</translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation>%1 (nepoužíváno: %2)</translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation>%1 (nepoužíváno: %2)</translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation>
+            <numerusform>%1 (nepoužíváno: %n)</numerusform>
+            <numerusform>%1 (nepoužíváno: %n)</numerusform>
+            <numerusform>%1 (nepoužíváno: %n)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5011,9 +5003,28 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
-        <translatorcomment>Byl(o) smazán(o) %1 vzorek (vzorků) a %2 nástroj (nástrojů).</translatorcomment>
-        <translation></translation>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
+        <translatorcomment>[Byl(o) smazán(o) X vzorek (vzorků)] a [Y nástroj (nástrojů)].</translatorcomment>
+        <translation>%1 a %2.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation>
+            <numerusform>Byl smazán %n vzorek</numerusform>
+            <numerusform>Byly smazány %n vzorky</numerusform>
+            <numerusform>Bylo smazáno %n vzorků</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation>
+            <numerusform>%n nástroj</numerusform>
+            <numerusform>%n nástroje</numerusform>
+            <numerusform>%n nástrojů</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5802,15 +5813,14 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 modulátor byl smazán.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>Bylo smazáno %1 modulátorů.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n modulátor byl smazán.</numerusform>
+            <numerusform>Byly smazány %n modulátory.</numerusform>
+            <numerusform>Bylo smazáno %n modulátorů.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_da.ts
+++ b/sources/polyphone_da.ts
@@ -2699,17 +2699,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 modulator:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 modulatorer:</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n modulator:</numerusform>
+            <numerusform>%n modulatorer:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2839,15 +2835,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>elementer</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>element</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n element</numerusform>
+            <numerusform>%n elementer</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3251,19 +3245,14 @@ frekvens</translation>
         <comment>kilo byte</comment>
         <translation>kB</translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation>%1 (ubrugte: %2)</translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation>%1 (ubrugt: %2)</translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation>
+            <numerusform>%1 (ubrugt: %n)</numerusform>
+            <numerusform>%1 (ubrugte: %n)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5030,8 +5019,26 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
-        <translation>%1 sample(s) og %2 instrument(er) er blevet slettet.</translation>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
+        <translatorcomment>[X sample(s)] og [Y instrument(er)] er blevet slettet.</translatorcomment>
+        <translation>%1 og %2 er blevet slettet.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation>
+            <numerusform>%n sample</numerusform>
+            <numerusform>%n samples</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation>
+            <numerusform>%n instrument</numerusform>
+            <numerusform>%n instrumenter</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5819,15 +5826,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 modulation er blevet slettet.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>%1 modulationer er blevet slettet.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n modulation er blevet slettet.</numerusform>
+            <numerusform>%n modulationer er blevet slettet.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_de.ts
+++ b/sources/polyphone_de.ts
@@ -2717,17 +2717,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation>Modulator areal einblenden</translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 Modulator:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 Modulatoren:</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n Modulator:</numerusform>
+            <numerusform>%n Modulatoren:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2857,15 +2853,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>Elemente</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>Element</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n Element</numerusform>
+            <numerusform>%n Elemente</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3302,19 +3296,14 @@ Frequenz</translation>
         <comment>kilo byte</comment>
         <translation>kB</translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation>%1 (ungenutzt: %2)</translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation>%1 (ungenutzt: %2)</translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation>
+            <numerusform>%1 (ungenutzt: %n)</numerusform>
+            <numerusform>%1 (ungenutzt: %n)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5080,8 +5069,26 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
-        <translation>%1 Sample(s) und %2 Instrument(e) wurden entfernt.</translation>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
+        <translatorcomment>[X Sample(s)] und [Y Instrument(e)] wurden entfernt.</translatorcomment>
+        <translation>%1 und %2 wurden entfernt.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation>
+            <numerusform>%n Sample</numerusform>
+            <numerusform>%n Samples</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation>
+            <numerusform>%n Instrument</numerusform>
+            <numerusform>%n Instrumente</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5870,15 +5877,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 Modulator wurde entfernt.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>%1 Modulatoren wurden entfernt.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n Modulator wurde entfernt.</numerusform>
+            <numerusform>%n Modulatoren wurden entfernt.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_en.ts
+++ b/sources/polyphone_en.ts
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN" sourcelanguage="en_US">
+<TS version="2.1" language="en">
 <context>
     <name>AbstractInputParser</name>
     <message>
         <location filename="core/input/abstractinputparser.cpp" line="42"/>
         <source>not processed yet</source>
-        <translation type="unfinished">未处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/abstractinputparser.cpp" line="81"/>
         <source>This file is already open.</source>
-        <translation type="unfinished">该文件已打开。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19,7 +19,7 @@
     <message>
         <location filename="core/output/abstractoutput.cpp" line="40"/>
         <source>not processed yet</source>
-        <translation>未处理</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -27,12 +27,12 @@
     <message>
         <location filename="editor/tools/abstracttool.cpp" line="122"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/abstracttool.cpp" line="127"/>
         <source>Information</source>
-        <translation>信息</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -40,82 +40,82 @@
     <message>
         <location filename="core/types/attribute.cpp" line="467"/>
         <source>absolute value</source>
-        <translation>绝对值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="578"/>
         <source>unknown</source>
-        <translation>未知</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="583"/>
         <source>Sample start offset</source>
-        <translation>样本起点偏移</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="589"/>
         <source>Sample end offset</source>
-        <translation>样本终点偏移</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="595"/>
         <source>Loop start offset</source>
-        <translation>循环起点偏移</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="601"/>
         <source>Loop end offset</source>
-        <translation>循环终点偏移</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="598"/>
         <source>Loop start offset (× 32768)</source>
-        <translation>循环起点偏移 (× 32768)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="607"/>
         <source>Mod LFO → pitch (c)</source>
-        <translation>Mod LFO → pitch (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="610"/>
         <source>Vib LFO → pitch (c)</source>
-        <translation>Vib LFO → pitch (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="613"/>
         <source>Mod env → pitch (c)</source>
-        <translation>Mod env → pitch (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="616"/>
         <source>Filter, cutoff (×)</source>
-        <translation>Filter, cutoff (×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="617"/>
         <source>Filter, cutoff (Hz)</source>
-        <translation>Filter, cutoff (Hz)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="620"/>
         <source>Filter, resonance (dB)</source>
-        <translation>Filter, resonance (dB)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="623"/>
         <source>Mod LFO → filter (c)</source>
-        <translation>Mod LFO → filter (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="626"/>
         <source>Mod env → filter (c)</source>
-        <translation>Mod env → filter (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="592"/>
         <source>Sample end offset (× 32768)</source>
-        <translation>样本终点偏移 (× 32768)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="586"/>
@@ -125,222 +125,222 @@
     <message>
         <location filename="core/types/attribute.cpp" line="629"/>
         <source>Mod LFO → volume (dB)</source>
-        <translation>Mod LFO → volume (dB)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="632"/>
         <source>Chorus (%)</source>
-        <translation>和声(%)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="635"/>
         <source>Reverb (%)</source>
-        <translation>混响(%)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="638"/>
         <source>Pan [-100;100]</source>
-        <translation>平衡[-100:100]</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="639"/>
         <source>Pan [-50;50]</source>
-        <translation>平衡[-50:50]</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="642"/>
         <source>Mod LFO delay (×)</source>
-        <translation>Mod LFO delay (×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="643"/>
         <source>Mod LFO delay (s)</source>
-        <translation>Mod LFO delay (s)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="646"/>
         <source>Mod LFO freq (×)</source>
-        <translation>Mod LFO freq (×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="647"/>
         <source>Mod LFO freq (Hz)</source>
-        <translation>Mod LFO freq (Hz)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="650"/>
         <source>Vib LFO delay (×)</source>
-        <translation>Vib LFO delay (×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="651"/>
         <source>Vib LFO delay (s)</source>
-        <translation>Vib LFO delay (s)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="654"/>
         <source>Vib LFO freq (×)</source>
-        <translation>Vib LFO freq (×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="655"/>
         <source>Vib LFO freq (Hz)</source>
-        <translation>Vib LFO freq (Hz)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="658"/>
         <source>Mod env delay (×)</source>
-        <translation>调制包络延迟(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="659"/>
         <source>Mod env delay (s)</source>
-        <translation>调制包络延迟(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="662"/>
         <source>Mod env attack (×)</source>
-        <translation>调制包络起音(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="663"/>
         <source>Mod env attack (s)</source>
-        <translation>调制包络起音(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="666"/>
         <source>Mod env hold (×)</source>
-        <translation>调制包络保持(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="667"/>
         <source>Mod env hold (s)</source>
-        <translation>调制包络保持(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="670"/>
         <source>Mod env decay (×)</source>
-        <translation>调制包络衰减(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="671"/>
         <source>Mod env decay (s)</source>
-        <translation>调制包络衰减(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="674"/>
         <source>Mod env sustain (%)</source>
-        <translation>调制包络延音(%)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="677"/>
         <source>Mod env release (×)</source>
-        <translation>调制包络释音(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="678"/>
         <source>Mod env release (s)</source>
-        <translation>调制包络释音(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="681"/>
         <source>Key → Mod env hold (c)</source>
-        <translation>Key → Mod env hold (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="684"/>
         <source>Key → Mod env decay (c)</source>
-        <translation>Key → Mod env decay (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="687"/>
         <source>Vol env delay (×)</source>
-        <translation>音量包络延迟(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="688"/>
         <source>Vol env delay (s)</source>
-        <translation>音量包络延迟(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="691"/>
         <source>Vol env attack (×)</source>
-        <translation>音量包络起音(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="692"/>
         <source>Vol env attack (s)</source>
-        <translation>音量包络起音(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="695"/>
         <source>Vol env hold (×)</source>
-        <translation>音量包络保持(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="696"/>
         <source>Vol env hold (s)</source>
-        <translation>音量包络保持(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="699"/>
         <source>Vol env decay (×)</source>
-        <translation>音量包络衰减(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="700"/>
         <source>Vol env decay (s)</source>
-        <translation>音量包络衰减(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="703"/>
         <source>Vol env sustain (dB)</source>
-        <translation>音量包络延音(分贝)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="706"/>
         <source>Vol env release (×)</source>
-        <translation>音量包络释音(×)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="707"/>
         <source>Vol env release (s)</source>
-        <translation>音量包络释音(秒)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="710"/>
         <source>Key → Vol env hold (c)</source>
-        <translation>Key → Vol env hold (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="713"/>
         <source>Key → Vol env decay (c)</source>
-        <translation>Key → Vol env decay (c)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="716"/>
         <source>Key range</source>
-        <translation>音符范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="719"/>
         <source>Velocity range</source>
-        <translation>力度范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="722"/>
         <source>Fixed key</source>
-        <translation>固定音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="725"/>
         <source>Fixed velocity</source>
-        <translation>固定力度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="728"/>
         <source>Attenuation (dB)</source>
-        <translation>衰减(分贝)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="749"/>
@@ -370,37 +370,37 @@
     <message>
         <location filename="core/types/attribute.cpp" line="604"/>
         <source>Loop end offset (× 32768)</source>
-        <translation>循环终点偏移(× 32768)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="731"/>
         <source>Tuning (semi-tones)</source>
-        <translation>校音(半音)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="734"/>
         <source>Tuning (cents)</source>
-        <translation>校音(音分)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="737"/>
         <source>Loop playback</source>
-        <translation>循环播放</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="740"/>
         <source>Scale tuning</source>
-        <translation>音阶调整</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="743"/>
         <source>Exclusive class</source>
-        <translation>独占类</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="746"/>
         <source>Root key</source>
-        <translation>根音符</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -409,313 +409,313 @@
         <location filename="context/confmanager.cpp" line="194"/>
         <source>Z</source>
         <comment>first key mapping for bottom left C</comment>
-        <translation>Z</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="195"/>
         <source>S</source>
         <comment>first key mapping for bottom C#</comment>
-        <translation>S</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="196"/>
         <source>X</source>
         <comment>first key mapping for bottom D</comment>
-        <translation>X</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="197"/>
         <source>D</source>
         <comment>first key mapping for bottom D#</comment>
-        <translation>D</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="198"/>
         <source>C</source>
         <comment>first key mapping for bottom E</comment>
-        <translation>C</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="199"/>
         <source>V</source>
         <comment>first key mapping for bottom F</comment>
-        <translation>V</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="200"/>
         <source>G</source>
         <comment>first key mapping for bottom F#</comment>
-        <translation>G</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="201"/>
         <source>B</source>
         <comment>first key mapping for bottom G</comment>
-        <translation>B</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="202"/>
         <source>H</source>
         <comment>first key mapping for bottom G#</comment>
-        <translation>H</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="203"/>
         <source>N</source>
         <comment>first key mapping for bottom A</comment>
-        <translation>N</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="204"/>
         <source>J</source>
         <comment>first key mapping for bottom A#</comment>
-        <translation>J</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="205"/>
         <source>M</source>
         <comment>first key mapping for bottom B</comment>
-        <translation>M</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="206"/>
         <source>,</source>
         <comment>first key mapping for bottom right C</comment>
-        <translation>,</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="212"/>
         <source>Q</source>
         <comment>first key mapping for upper left C</comment>
-        <translation>Q</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="213"/>
         <source>2</source>
         <comment>first key mapping for upper C#</comment>
-        <translation>2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="214"/>
         <source>W</source>
         <comment>first key mapping for upper D</comment>
-        <translation>W</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="215"/>
         <source>3</source>
         <comment>first key mapping for upper D#</comment>
-        <translation>3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="216"/>
         <source>E</source>
         <comment>first key mapping for upper E</comment>
-        <translation>E</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="217"/>
         <source>R</source>
         <comment>first key mapping for upper F</comment>
-        <translation>R</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="218"/>
         <source>5</source>
         <comment>first key mapping for upper F#</comment>
-        <translation>5</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="219"/>
         <source>T</source>
         <comment>first key mapping for upper G</comment>
-        <translation>T</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="220"/>
         <source>6</source>
         <comment>first key mapping for upper G#</comment>
-        <translation>6</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="221"/>
         <source>Y</source>
         <comment>first key mapping for upper A</comment>
-        <translation>Y</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="222"/>
         <source>7</source>
         <comment>first key mapping for upper A#</comment>
-        <translation>7</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="223"/>
         <source>U</source>
         <comment>first key mapping for upper B</comment>
-        <translation>U</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="224"/>
         <source>I</source>
         <comment>first key mapping for upper right C</comment>
-        <translation>I</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="230"/>
         <source>Shift+Z</source>
         <comment>second key mapping for bottom left C</comment>
-        <translation>Shift+Z</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="231"/>
         <source>Shift+S</source>
         <comment>second key mapping for bottom C#</comment>
-        <translation>Shift+S</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="232"/>
         <source>Shift+X</source>
         <comment>second key mapping for bottom D</comment>
-        <translation>Shift+X</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="233"/>
         <source>Shift+D</source>
         <comment>second key mapping for bottom D#</comment>
-        <translation>Shift+D</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="234"/>
         <source>Shift+C</source>
         <comment>second key mapping for bottom E</comment>
-        <translation>Shift+C</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="235"/>
         <source>Shift+V</source>
         <comment>second key mapping for bottom F</comment>
-        <translation>Shift+V</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="236"/>
         <source>Shift+G</source>
         <comment>second key mapping for bottom F#</comment>
-        <translation>Shift+G</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="237"/>
         <source>Shift+B</source>
         <comment>second key mapping for bottom G</comment>
-        <translation>Shift+B</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="238"/>
         <source>Shift+H</source>
         <comment>second key mapping for bottom G#</comment>
-        <translation>Shift+H</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="239"/>
         <source>Shift+N</source>
         <comment>second key mapping for bottom A</comment>
-        <translation>Shift+N</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="240"/>
         <source>Shift+J</source>
         <comment>second key mapping for bottom A#</comment>
-        <translation>Shift+J</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="241"/>
         <source>Shift+M</source>
         <comment>second key mapping for bottom B</comment>
-        <translation>Shift+M</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="242"/>
         <source>Shift+&lt;</source>
         <comment>second key mapping for bottom right C</comment>
-        <translation>Shift+&lt;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="248"/>
         <source>Shift+Q</source>
         <comment>second key mapping for upper left C</comment>
-        <translation>Shift+Q</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="249"/>
         <source>Shift+@</source>
         <comment>second key mapping for upper C#</comment>
-        <translation>Shift+@</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="250"/>
         <source>Shift+W</source>
         <comment>second key mapping for upper D</comment>
-        <translation>Shift+W</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="251"/>
         <source>Shift+#</source>
         <comment>second key mapping for upper D#</comment>
-        <translation>Shift+#</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="252"/>
         <source>Shift+E</source>
         <comment>second key mapping for upper E</comment>
-        <translation>Shift+E</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="253"/>
         <source>Shift+R</source>
         <comment>second key mapping for upper F</comment>
-        <translation>Shift+R</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="254"/>
         <source>Shift+%</source>
         <comment>second key mapping for upper F#</comment>
-        <translation>Shift+%</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="255"/>
         <source>Shift+T</source>
         <comment>second key mapping for upper G</comment>
-        <translation>Shift+T</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="256"/>
         <source>Shift+^</source>
         <comment>second key mapping for upper G#</comment>
-        <translation>Shift+^</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="257"/>
         <source>Shift+Y</source>
         <comment>second key mapping for upper A</comment>
-        <translation>Shift+Y</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="258"/>
         <source>Shift+&amp;</source>
         <comment>second key mapping for upper A#</comment>
-        <translation>Shift+&amp;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="259"/>
         <source>Shift+U</source>
         <comment>second key mapping for upper B</comment>
-        <translation>Shift+U</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/confmanager.cpp" line="260"/>
         <source>Shift+I</source>
         <comment>second key mapping for upper right C</comment>
-        <translation>Shift+I</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -723,27 +723,27 @@
     <message>
         <location filename="context/interface/configpanel.ui" line="81"/>
         <source>General</source>
-        <translation>通用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configpanel.ui" line="114"/>
         <source>Interface</source>
-        <translation>界面</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configpanel.ui" line="147"/>
         <source>Sound</source>
-        <translation>音频</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configpanel.ui" line="180"/>
         <source>Virtual keyboard</source>
-        <translation>虚拟键盘</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configpanel.ui" line="213"/>
         <source>Online repository</source>
-        <translation>在线仓库</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -751,54 +751,54 @@
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="26"/>
         <source>Input / Output</source>
-        <translation>输入/输出</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="95"/>
         <source>Audio backend</source>
-        <translation>音频后端</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="124"/>
         <source>Buffer size</source>
-        <translation>缓冲大小</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="147"/>
         <source>MIDI input</source>
         <oldsource>Midi input</oldsource>
-        <translation>MIDI 输入</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="163"/>
         <source>Options</source>
-        <translation>选项</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="178"/>
         <source>Sample import</source>
         <oldsource>Wav file import</oldsource>
-        <translation type="unfinished">WAV 文件导入</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="191"/>
         <source>change linked sample</source>
-        <translation>修改链接的样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="204"/>
         <source>trim to loop</source>
-        <translation>裁剪样本至循环部分</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="217"/>
         <source>Stereo editing</source>
-        <translation>双声道编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectiongeneral.ui" line="230"/>
         <source>remove blank at start</source>
-        <translation>移除开头空白</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -806,78 +806,78 @@
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="57"/>
         <source>Language</source>
-        <translation>语言</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="44"/>
         <source>Key names</source>
-        <translation>音符名格式</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="26"/>
         <source>Options</source>
-        <translation>选项</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="113"/>
         <source>Middle C → 60, then 61</source>
-        <translation>中央 C → 60，之后为 61</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="118"/>
         <source>Middle C → C3, then C♯3</source>
-        <translation>中央 C → C3，之后为 C♯3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="123"/>
         <source>Middle C → C3, then D♭3</source>
-        <translation>中央 C → C3，之后为 D♭3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="128"/>
         <source>Middle C → C4, then C♯4</source>
-        <translation>中央 C → C4，之后为 C♯4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="133"/>
         <source>Middle C → C4, then D♭4</source>
-        <translation>中央 C → C4，之后为 D♭4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="138"/>
         <source>Middle C → C5, then C♯5</source>
-        <translation>中央 C → C5，之后为 C♯5</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="143"/>
         <source>Middle C → C5, then D♭5</source>
-        <translation>中央 C → C5，之后为 D♭5</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="157"/>
         <source>Sort divisions</source>
-        <translation>排序方式</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="77"/>
         <source>by key range</source>
-        <translation>按音符范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="82"/>
         <source>by velocity range</source>
-        <translation>按力度范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="87"/>
         <source>in alphabetical order</source>
-        <translation>按字母顺序</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="92"/>
         <source>none</source>
         <comment>speaking of the &quot;sort divisions&quot;</comment>
-        <translation>无</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="183"/>
@@ -887,42 +887,42 @@
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="212"/>
         <source>Theme</source>
-        <translation>主题</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="483"/>
         <source>Selection</source>
-        <translation>选择</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="245"/>
         <source>Text</source>
-        <translation>文本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="320"/>
         <source>Window</source>
-        <translation>窗口</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="439"/>
         <source>Background</source>
-        <translation>背景</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="420"/>
         <source>Button</source>
-        <translation>按钮</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="558"/>
         <source>List and table</source>
-        <translation>表格和列表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.ui" line="610"/>
         <source>This modification will be applied during the next start of the software.</source>
-        <translation>设置将在下次启动程序时生效。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectioninterface.cpp" line="161"/>
@@ -935,7 +935,7 @@
         <location filename="context/interface/configsectioninterface.cpp" line="245"/>
         <location filename="context/interface/configsectioninterface.cpp" line="257"/>
         <source>Select a color</source>
-        <translation>选择颜色</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -943,27 +943,27 @@
     <message>
         <location filename="context/interface/configsectionkeyboard.ui" line="45"/>
         <source>Octave #1</source>
-        <translation>八度 #1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionkeyboard.ui" line="50"/>
         <source>Octave #2</source>
-        <translation>八度 #2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionkeyboard.ui" line="55"/>
         <source>Octave #3</source>
-        <translation>八度 #3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionkeyboard.ui" line="60"/>
         <source>Octave #4</source>
-        <translation>八度 #4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionkeyboard.ui" line="133"/>
         <source>First C</source>
-        <translation>起始 C</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -971,73 +971,73 @@
     <message>
         <location filename="context/interface/configsectionrepository.ui" line="20"/>
         <source>Username</source>
-        <translation>用户名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.ui" line="67"/>
         <source>Create an account</source>
-        <translation>创建账户</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.ui" line="114"/>
         <source>Become
 Premium!</source>
-        <translation>升级高级账户！</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.ui" line="195"/>
         <source>Banned account</source>
-        <translation>已封禁账户</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.ui" line="255"/>
         <source>Password</source>
-        <translation>密码</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.ui" line="274"/>
         <source>Download directory</source>
-        <translation>下载目录</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="105"/>
         <location filename="context/interface/configsectionrepository.cpp" line="135"/>
         <source>Connection</source>
-        <translation>连接</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="108"/>
         <source>Connecting...</source>
-        <translation>正在连接...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="112"/>
         <source>Cancel</source>
-        <translation>取消</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="115"/>
         <location filename="context/interface/configsectionrepository.cpp" line="121"/>
         <source>Connected</source>
-        <translation>已连接</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="118"/>
         <location filename="context/interface/configsectionrepository.cpp" line="124"/>
         <location filename="context/interface/configsectionrepository.cpp" line="129"/>
         <source>Log out</source>
-        <translation>退出账户</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="194"/>
         <location filename="context/interface/configsectionrepository.cpp" line="201"/>
         <source>Click on %1 to save parameters.</source>
-        <translation>点击%1以保存参数。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionrepository.cpp" line="207"/>
         <source>Select the destination directory</source>
-        <translation>选择目标目录</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1045,23 +1045,23 @@ Premium!</source>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="191"/>
         <source>Reverb</source>
-        <translation>混响</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="249"/>
         <source>Gain (dB)</source>
-        <translation>增益(dB)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="298"/>
         <source>Width</source>
-        <translation>宽度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="65"/>
         <location filename="context/interface/configsectionsound.ui" line="333"/>
         <source>Level</source>
-        <translation>大小</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="157"/>
@@ -1087,27 +1087,27 @@ Premium!</source>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="388"/>
         <source>Damp</source>
-        <translation>湿度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="404"/>
         <source>Room</source>
-        <translation>体积</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="32"/>
         <source>Chorus</source>
-        <translation>和声</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="113"/>
         <source>Frequency</source>
-        <translation>频率</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configsectionsound.ui" line="129"/>
         <source>Depth</source>
-        <translation>深度</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1115,28 +1115,28 @@ Premium!</source>
     <message>
         <location filename="context/interface/configtoc.ui" line="59"/>
         <source>General</source>
-        <translation>通用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configtoc.ui" line="72"/>
         <source>Interface</source>
-        <translation>界面</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configtoc.ui" line="85"/>
         <source>Sound</source>
-        <translation>音频</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configtoc.ui" line="98"/>
         <source>Virtual keyboard</source>
-        <translation>虚拟键盘</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/interface/configtoc.ui" line="111"/>
         <source>Online
 repository</source>
-        <translation>在线仓库</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1172,103 +1172,103 @@ repository</source>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="53"/>
         <source>Cannot create directory &quot;%1&quot;</source>
-        <translation>无法创建目录 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="258"/>
         <source>untitled</source>
-        <translation>未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="543"/>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="585"/>
         <source>other</source>
-        <translation>其它</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="546"/>
         <source>Piano</source>
-        <translation>钢琴</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="548"/>
         <source>Chromatic percussion</source>
-        <translation>半音阶打击乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="550"/>
         <source>Organ</source>
-        <translation>风琴</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="552"/>
         <source>Guitar</source>
-        <translation>吉他</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="554"/>
         <source>Bass</source>
-        <translation>低音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="556"/>
         <source>Strings</source>
-        <translation>弦乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="558"/>
         <source>Ensemble</source>
-        <translation>和弦</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="560"/>
         <source>Brass</source>
-        <translation>铜管乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="562"/>
         <source>Reed</source>
-        <translation>簧乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="564"/>
         <source>Pipe</source>
-        <translation>管乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="566"/>
         <source>Synth lead</source>
-        <translation>合成主音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="568"/>
         <source>Synth pad</source>
-        <translation>合成柔音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="570"/>
         <source>Synth effects</source>
-        <translation>合成音效</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="572"/>
         <source>Ethnic</source>
-        <translation>民乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="574"/>
         <source>Percussive</source>
-        <translation>打击乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="576"/>
         <source>Sound effects</source>
-        <translation>音效</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sfz/conversion_sfz.cpp" line="578"/>
         <source>Percussion kit</source>
-        <translation>打击乐组</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1276,14 +1276,14 @@ repository</source>
     <message>
         <location filename="repository/detailsmanager.cpp" line="136"/>
         <source>Subscribe to a Premium account to get all the features!</source>
-        <translation>订阅高级账户获取所有功能!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/detailsmanager.cpp" line="139"/>
         <location filename="repository/detailsmanager.cpp" line="142"/>
         <location filename="repository/detailsmanager.cpp" line="148"/>
         <source>Server error</source>
-        <translation>服务器错误</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1291,134 +1291,129 @@ repository</source>
     <message>
         <location filename="dialogs/dialog_about.ui" line="29"/>
         <source>About</source>
-        <translation>关于</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.ui" line="177"/>
         <source>Credit</source>
-        <translation>制作人员</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.ui" line="200"/>
         <source>Close</source>
-        <translation>关闭</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="36"/>
         <source>Polyphone</source>
-        <translation>Polyphone</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="49"/>
         <source>Copyright</source>
-        <translation>版权</translation>
+        <oldsource>Copyright © </oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="53"/>
         <source>Polyphone website</source>
-        <translation>Polyphone 官方网站</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="57"/>
         <source>Donate</source>
-        <translation>捐赠</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="61"/>
-        <location filename="dialogs/dialog_about.cpp" line="72"/>
+        <location filename="dialogs/dialog_about.cpp" line="70"/>
         <source>Davy Triponney</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Davy Triponney</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="63"/>
-        <location filename="dialogs/dialog_about.cpp" line="70"/>
+        <location filename="dialogs/dialog_about.cpp" line="69"/>
         <source>Andrea Celani</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Andrea Celani</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="64"/>
         <source>Kinwie</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Kinwie</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="65"/>
         <source>Michael Schyllberg</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Michael Schyllberg</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="66"/>
         <source>Paul Stratman</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Paul Stratman</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="67"/>
-        <location filename="dialogs/dialog_about.cpp" line="79"/>
+        <location filename="dialogs/dialog_about.cpp" line="77"/>
         <source>Steve Clarke</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Steve Clarke</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="69"/>
-        <source>Aleksey Bobylev</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Aleksey Bobylev</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="73"/>
-        <source>F.J. Martínez Murcia</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>F.J. Martínez Murcia</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="74"/>
-        <source>Georg Gergull</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Georg Gergull</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="75"/>
-        <source>Jay Alexander Fleming</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Jay Alexander Fleming</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="76"/>
-        <source>Joel Gomes</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Joel Gomes</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="77"/>
-        <source>Magson</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Magson</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="78"/>
-        <source>Pavel Fric</source>
-        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation>Pavel Fric</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="71"/>
+        <source>F.J. Martínez Murcia</source>
+        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="72"/>
+        <source>Georg Gergull</source>
+        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="73"/>
+        <source>Jay Alexander Fleming</source>
+        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="74"/>
+        <source>Joel Gomes</source>
+        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="75"/>
+        <source>Magson</source>
+        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="76"/>
+        <source>Pavel Fric</source>
+        <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="78"/>
         <source>Chris Hansen</source>
         <comment>translation needed if the alphabet is not the same (cyrillic for instance)</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="50"/>
         <source>Davy Triponney</source>
-        <translation>Davy Triponney</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="47"/>
         <source>https://www.polyphone-soundfonts.com/en</source>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1426,42 +1421,42 @@ repository</source>
     <message>
         <location filename="dialogs/dialogchangelog.ui" line="17"/>
         <source>Welcome</source>
-        <translation>欢迎</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.ui" line="87"/>
         <source>&amp;Donate</source>
-        <translation>捐赠(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.ui" line="107"/>
         <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.cpp" line="48"/>
         <source>Thank you for having installed</source>
-        <translation>感谢您安装了</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.cpp" line="49"/>
         <source>Polyphone</source>
-        <translation>Polyphone</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.cpp" line="91"/>
         <source>What is new</source>
-        <translation>新变化</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.cpp" line="94"/>
         <source>What has improved</source>
-        <translation>改进部分</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogchangelog.cpp" line="97"/>
         <source>What is fixed</source>
-        <translation>修复问题</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1469,57 +1464,57 @@ repository</source>
     <message>
         <location filename="dialogs/dialogcreateelements.ui" line="17"/>
         <source>Question</source>
-        <translation>问题</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.ui" line="122"/>
         <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.ui" line="102"/>
         <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="72"/>
         <source>Create an instrument comprising the sample %1?</source>
-        <translation>由 %1 样本组合创建乐器？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="78"/>
         <source>Create an instrument</source>
-        <translation>创建乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="79"/>
         <source>for each sample</source>
-        <translation>为每个样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="80"/>
         <source>comprising the %1 samples</source>
-        <translation>正在组合 %1 样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="88"/>
         <source>Create a preset comprising the instrument %1?</source>
-        <translation>由 %1 乐器组合创建预设?</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="94"/>
         <source>Create a preset</source>
-        <translation>创建预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="95"/>
         <source>for each instrument</source>
-        <translation>为每个乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogcreateelements.cpp" line="96"/>
         <source>comprising the %1 instruments</source>
-        <translation>正在组合 %1 乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1527,37 +1522,37 @@ repository</source>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="14"/>
         <source>Virtual keyboard</source>
-        <translation>虚拟键盘</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="108"/>
         <source>5 octaves</source>
-        <translation>5 个八度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="113"/>
         <source>6 octaves</source>
-        <translation>6 个八度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="118"/>
         <source>88 keys (piano)</source>
-        <translation>88 键(钢琴)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="123"/>
         <source>128 keys (full)</source>
-        <translation>128 键(全 MIDI 范围)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="150"/>
         <source>Key</source>
-        <translation>音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="176"/>
         <source>Velocity</source>
-        <translation>力度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogkeyboard.ui" line="202"/>
@@ -1580,28 +1575,27 @@ repository</source>
     <message>
         <location filename="dialogs/dialog_list.cpp" line="53"/>
         <source>Sample list</source>
-        <oldsource>Liste des samples</oldsource>
-        <translation>样本列表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_list.cpp" line="58"/>
         <source>Instrument list</source>
-        <translation>乐器列表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_list.cpp" line="63"/>
         <source>Preset list</source>
-        <translation>预设列表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_list.ui" line="64"/>
         <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_list.ui" line="44"/>
         <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1609,22 +1603,22 @@ repository</source>
     <message>
         <location filename="dialogs/dialognewelement.ui" line="51"/>
         <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialognewelement.ui" line="58"/>
         <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialognewelement.cpp" line="49"/>
         <source>Create a new preset</source>
-        <translation type="unfinished">创建新预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialognewelement.cpp" line="49"/>
         <source>Create a new instrument</source>
-        <translation type="unfinished">创建新乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialognewelement.cpp" line="50"/>
@@ -1653,7 +1647,7 @@ repository</source>
     <message>
         <location filename="dialogs/dialogquestion.ui" line="35"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogquestion.ui" line="42"/>
@@ -1666,23 +1660,23 @@ repository</source>
     <message>
         <location filename="dialogs/dialogrecorder.ui" line="26"/>
         <source>Recorder</source>
-        <translation>录音机</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogrecorder.cpp" line="102"/>
         <source>Save a record</source>
-        <translation>保存录音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogrecorder.cpp" line="103"/>
         <source>Wav file</source>
-        <translation>WAV 文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogrecorder.cpp" line="161"/>
         <location filename="dialogs/dialogrecorder.cpp" line="163"/>
         <source>record</source>
-        <translation>录音</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1690,28 +1684,28 @@ repository</source>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="23"/>
         <source>Bulk rename</source>
-        <translation>批量重命名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="66"/>
         <source>Replace characters</source>
-        <translation>替换文本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="71"/>
         <source>Insert after a specific position</source>
-        <translation>在指定位置插入文本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="76"/>
         <source>Delete character range</source>
-        <translation>删除指定范围文本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="121"/>
         <location filename="dialogs/dialog_rename.cpp" line="103"/>
         <source>Position</source>
-        <translation>位置</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="157"/>
@@ -1721,43 +1715,43 @@ repository</source>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="137"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="56"/>
         <source>Overwrite existing name with key name as suffix</source>
-        <translation>为名称添加音符名后缀</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.ui" line="61"/>
         <source>Overwrite existing name with numerical ascending suffix</source>
-        <translation>为名称添加升序数字后缀</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.cpp" line="69"/>
         <location filename="dialogs/dialog_rename.cpp" line="80"/>
         <source>New name:</source>
-        <translation>新名称：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.cpp" line="91"/>
         <source>Find:</source>
-        <translation>查找：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.cpp" line="94"/>
         <source>And replace by:</source>
-        <translation>并替换：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.cpp" line="104"/>
         <source>Text to insert:</source>
-        <translation>插入文本：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_rename.cpp" line="115"/>
         <source>Range</source>
-        <translation>范围</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1765,28 +1759,28 @@ repository</source>
     <message>
         <location filename="dialogs/dialogselection.ui" line="17"/>
         <source>Duplicate</source>
-        <translation>创建副本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogselection.ui" line="30"/>
         <source>Select all</source>
-        <translation>全选</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogselection.ui" line="37"/>
         <source>Unselect all</source>
-        <translation>全不选</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogselection.ui" line="66"/>
         <source>&amp;Cancel</source>
         <oldsource>Cancel</oldsource>
-        <translation>取消(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialogselection.ui" line="46"/>
         <source>&amp;Duplicate</source>
-        <translation type="unfinished">创建副本(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1795,17 +1789,17 @@ repository</source>
         <location filename="repository/downloadmanager.cpp" line="110"/>
         <location filename="repository/downloadmanager.cpp" line="158"/>
         <source>untitled</source>
-        <translation>未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/downloadmanager.cpp" line="144"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/downloadmanager.cpp" line="145"/>
         <source>Couldn&apos;t download file &quot;%1&quot;: %2</source>
-        <translation>无法下载文件 &quot;%1&quot;: %2</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1813,7 +1807,7 @@ repository</source>
     <message>
         <location filename="repository/widgets/downloadprogressbutton.cpp" line="45"/>
         <source>Clear completed downloads</source>
-        <translation>清除完成的下载</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1821,28 +1815,28 @@ repository</source>
     <message>
         <location filename="repository/widgets/downloadprogresscell.ui" line="51"/>
         <source>Cancel download</source>
-        <translation>取消下载</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/widgets/downloadprogresscell.cpp" line="70"/>
         <source>Open &quot;%1&quot;</source>
         <oldsource>Open &quot;%0&quot;</oldsource>
-        <translation>打开 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/widgets/downloadprogresscell.cpp" line="89"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/widgets/downloadprogresscell.cpp" line="90"/>
         <source>Couldn&apos;t open file &quot;%1&quot;. If this is an archive, you may have to extract it first.</source>
-        <translation>无法打开文件 &quot;%1&quot;。如果这是个压缩文件，需要解压后再打开。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/widgets/downloadprogresscell.cpp" line="107"/>
         <source>Download canceled</source>
-        <translation>下载已取消</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1850,77 +1844,77 @@ repository</source>
     <message>
         <location filename="core/duplicator.cpp" line="296"/>
         <source>Global parameters are already filled.</source>
-        <translation>全局参数已填充。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="297"/>
         <source>The global division will not be copied.</source>
-        <translation>全局分层将不会被复制。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="299"/>
         <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="300"/>
         <source>Ok, &amp;disable this message</source>
-        <translation>确定并不再提示(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="332"/>
         <source>The sample &quot;%1&quot; already exists.&lt;br /&gt;Replace?</source>
-        <translation>样本 &quot;%1&quot; 已存在。&lt;br/&gt;是否替换？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="472"/>
         <source>The instrument &quot;%1&quot; already exists.&lt;br /&gt;Replace?</source>
-        <translation>乐器 &quot;%1&quot; 已存在。&lt;br/&gt;是否替换？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="567"/>
         <source>The preset &quot;%1&quot; already exists.&lt;br/&gt;Replace?</source>
-        <translation>预设 &quot;%1&quot; 已存在。&lt;br/&gt;是否替换？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="589"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="590"/>
         <source>No preset available.</source>
-        <translation>无预设可用。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="788"/>
         <source>&amp;Replace</source>
-        <translation>替换(&amp;R)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="789"/>
         <source>R&amp;eplace all</source>
-        <translation>全部替换(&amp;A)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="790"/>
         <source>&amp;Duplicate</source>
-        <translation>创建副本(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="791"/>
         <source>D&amp;uplicate all</source>
-        <translation>全部创建副本(&amp;U)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="792"/>
         <source>&amp;Ignore</source>
-        <translation>忽略(&amp;I)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/duplicator.cpp" line="793"/>
         <source>I&amp;gnore all</source>
-        <translation>全部忽略(&amp;G)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1928,22 +1922,22 @@ repository</source>
     <message>
         <location filename="editor/editor.ui" line="154"/>
         <source>Search...</source>
-        <translation>搜索...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/editor.ui" line="254"/>
         <source>Opening file...</source>
-        <translation>正在打开文件...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/editor.ui" line="385"/>
         <source>Cannot open the file</source>
-        <translation>无法打开文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/editor.cpp" line="208"/>
         <source>Untitled</source>
-        <translation>未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1979,7 +1973,7 @@ repository</source>
     <message>
         <location filename="repository/soundfont/editor/editordialoginsertlink.ui" line="27"/>
         <source>Link</source>
-        <translation type="unfinished">链接</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2013,52 +2007,52 @@ repository</source>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="55"/>
         <source>Add a sample</source>
-        <translation>添加样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="59"/>
         <source>Add an instrument</source>
-        <translation>添加乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="63"/>
         <source>Add a preset</source>
-        <translation>添加预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="67"/>
         <source>Toolbox</source>
-        <translation>工具栏</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="74"/>
         <source>Cancel</source>
-        <translation>取消</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="78"/>
         <source>Redo</source>
-        <translation>重做</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="83"/>
         <source>Save</source>
-        <translation>保存</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="93"/>
         <source>Recorder</source>
-        <translation>录音机</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="99"/>
         <source>Virtual keyboard</source>
-        <translation>虚拟键盘</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="257"/>
         <source>Import an audio file</source>
-        <translation>导入音频文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="259"/>
@@ -2073,7 +2067,7 @@ repository</source>
     <message>
         <location filename="editor/widgets/editortoolbar.cpp" line="374"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2086,76 +2080,75 @@ repository</source>
         <location filename="editor/envelopeditor.ui" line="401"/>
         <source> s</source>
         <comment>unit for second</comment>
-        <translation> 秒</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.ui" line="372"/>
         <source> dB</source>
         <comment>unit for decibels</comment>
-        <translation> 分贝</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.ui" line="279"/>
         <source>Delay</source>
-        <translation>延迟(Delay)</translation>
-    </message>
-    <message>
-        <location filename="editor/envelopeditor.ui" line="128"/>
-        <source>Decay</source>
-        <translation>衰减(Decay)</translation>
-    </message>
-    <message>
-        <location filename="editor/envelopeditor.ui" line="420"/>
-        <source>Sustain</source>
-        <translation>延音(Sustain)</translation>
-    </message>
-    <message>
-        <location filename="editor/envelopeditor.ui" line="263"/>
-        <source>Hold</source>
-        <translation>保持(Hold)</translation>
-    </message>
-    <message>
-        <location filename="editor/envelopeditor.ui" line="138"/>
-        <source>Release</source>
-        <translation>释音(Release)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.ui" line="181"/>
         <source>Key → Decay</source>
-        <translation>Key → Decay</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="editor/envelopeditor.ui" line="329"/>
-        <source>Attack</source>
-        <translation>起音(Attack)</translation>
+        <location filename="editor/envelopeditor.ui" line="128"/>
+        <source>Decay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/envelopeditor.ui" line="420"/>
+        <source>Sustain</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.ui" line="391"/>
         <source>Key → Hold</source>
-        <translation>Key → Hold</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/envelopeditor.ui" line="263"/>
+        <source>Hold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/envelopeditor.ui" line="138"/>
+        <source>Release</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/envelopeditor.ui" line="329"/>
+        <source>Attack</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.ui" line="458"/>
         <source>Volume envelope</source>
-        <translation>音量包络</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.ui" line="477"/>
         <source>Modulation envelope</source>
-        <oldsource>Modulation</oldsource>
-        <translation>调制包络</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.cpp" line="98"/>
         <source>dB</source>
         <comment>unit for decibels</comment>
-        <translation>分贝</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/envelopeditor.cpp" line="111"/>
         <source>%</source>
         <comment>percentage</comment>
-        <translation>%</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2168,17 +2161,17 @@ repository</source>
     <message>
         <location filename="editor/widgets/equalizer.ui" line="618"/>
         <source>Reset</source>
-        <translation type="unfinished">重设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/equalizer.ui" line="644"/>
         <source>Apply</source>
-        <translation type="unfinished">应用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/equalizer.cpp" line="144"/>
         <source>Information</source>
-        <translation type="unfinished">信息</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/equalizer.cpp" line="145"/>
@@ -2196,7 +2189,7 @@ repository</source>
     <message>
         <location filename="repository/browser/filterflow.cpp" line="63"/>
         <source>All</source>
-        <translation>全部</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2204,7 +2197,7 @@ repository</source>
     <message>
         <location filename="repository/browser/filtertag.ui" line="32"/>
         <source>Tag name...</source>
-        <translation>标签名称...</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2213,13 +2206,13 @@ repository</source>
         <location filename="editor/tools/sound_spatialization/graphspace.cpp" line="76"/>
         <source>L</source>
         <comment>first letter of Left in your language</comment>
-        <translation>左</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/graphspace.cpp" line="85"/>
         <source>R</source>
         <comment>first letter of Right in your language</comment>
-        <translation>右</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2227,7 +2220,7 @@ repository</source>
     <message>
         <location filename="editor/tools/monitor/graphvisualizer.cpp" line="236"/>
         <source>Cannot display all the values.</source>
-        <translation>无法显示所有的值。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2235,7 +2228,7 @@ repository</source>
     <message>
         <location filename="editor/graphics/graphicswave.cpp" line="181"/>
         <source>Multiple selection</source>
-        <translation type="unfinished">多选</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2243,33 +2236,33 @@ repository</source>
     <message>
         <location filename="editor/graphics/graphiquefourier.cpp" line="57"/>
         <source>Frequency (Hz)</source>
-        <translation>频率(赫兹)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphiquefourier.cpp" line="71"/>
         <source>Intensity</source>
-        <translation>强度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphiquefourier.cpp" line="88"/>
         <source>Export graph</source>
-        <translation>导出图表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphiquefourier.cpp" line="466"/>
         <source>Hz</source>
         <comment>unit for Herz</comment>
-        <translation>赫兹</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphiquefourier.cpp" line="486"/>
         <source>Export a graph</source>
-        <translation>导出图表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphiquefourier.cpp" line="487"/>
         <source>Png file</source>
-        <translation>PNG 文件</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2277,7 +2270,7 @@ repository</source>
     <message>
         <location filename="core/input/grandorgue/inputparsergrandorgue.cpp" line="77"/>
         <source>Cannot open file &quot;%1&quot;</source>
-        <translation type="unfinished">无法打开文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2285,7 +2278,7 @@ repository</source>
     <message>
         <location filename="core/input/not_supported/inputparsernotsupported.cpp" line="38"/>
         <source>This file format is not supported.</source>
-        <translation type="unfinished">该文件格式不被支持。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2293,12 +2286,12 @@ repository</source>
     <message>
         <location filename="core/input/sf2/inputparsersf2.cpp" line="48"/>
         <source>Cannot find file &quot;%1&quot;.</source>
-        <translation type="unfinished">无法找到文件 &quot;%1&quot;。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sf2/inputparsersf2.cpp" line="55"/>
         <source>Access denied for reading file &quot;%1&quot;.</source>
-        <translation type="unfinished">读取文件时被拒绝访问 &quot;%1&quot;。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2306,17 +2299,17 @@ repository</source>
     <message>
         <location filename="core/input/sf3/inputparsersf3.cpp" line="73"/>
         <source>Error during the sf3 =&gt; sf2 conversion</source>
-        <translation type="unfinished">转换 SF3 至 SF2 时发生错误</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sf3/inputparsersf3.cpp" line="78"/>
         <source>Cannot create file &quot;%1&quot;</source>
-        <translation type="unfinished">无法创建文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sf3/inputparsersf3.cpp" line="81"/>
         <source>Cannot read file &quot;%1&quot;</source>
-        <translation type="unfinished">无法读取文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2324,22 +2317,22 @@ repository</source>
     <message>
         <location filename="core/input/sfz/inputparsersfz.cpp" line="103"/>
         <source>File recursion</source>
-        <translation type="unfinished">递归文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sfz/inputparsersfz.cpp" line="111"/>
         <source>Cannot open file &quot;%1&quot;</source>
-        <translation type="unfinished">无法打开文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sfz/inputparsersfz.cpp" line="288"/>
         <source>Sfz import</source>
-        <translation type="unfinished">导入 SFZ 文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sfz/inputparsersfz.cpp" line="459"/>
         <source>untitled</source>
-        <translation type="unfinished">未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2347,57 +2340,57 @@ repository</source>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="39"/>
         <source>&amp;New</source>
-        <translation>新建(&amp;N)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="44"/>
         <source>&amp;Open...</source>
-        <translation>打开(&amp;O)...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="51"/>
         <source>&amp;Save</source>
-        <translation>保存(&amp;S)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="56"/>
         <source>Save &amp;as...</source>
-        <translation>另存为(&amp;A)...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="61"/>
         <source>&amp;Export soundfonts</source>
-        <translation>导出音色库(&amp;E)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="68"/>
         <source>&amp;Full screen</source>
-        <translation>全屏(&amp;F)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="76"/>
         <source>Se&amp;ttings</source>
-        <translation>设置(&amp;S)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="80"/>
         <source>Online &amp;manual</source>
-        <translation>在线手册(&amp;M)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="86"/>
         <source>About &amp;Polyphone...</source>
-        <translation>关于 Polyphone(&amp;P)...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="92"/>
         <source>&amp;Close file</source>
-        <translation>关闭文件(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainmenu.cpp" line="97"/>
         <source>&amp;Quit</source>
-        <translation>退出(&amp;Q)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2405,118 +2398,126 @@ repository</source>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="200"/>
         <source>&amp;Save</source>
-        <translation>保存(&amp;S)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="201"/>
         <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="202"/>
         <source>Do&amp;n&apos;t save</source>
-        <translation>不保存(&amp;N)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="186"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="176"/>
         <source>untitled</source>
-        <translation>未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="187"/>
         <source>Save before exiting?</source>
-        <translation>退出前是否保存文件？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="190"/>
         <source>The following files have been modified:</source>
-        <translation>下列文件已被修改：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="197"/>
         <source>File &quot;%1&quot; has been modified.</source>
-        <translation>文件 &quot;%1&quot; 已被修改。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="246"/>
         <source>en/documentation</source>
         <comment>path for the documentation online</comment>
-        <translation>en/documentation</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="251"/>
         <source>en/forum</source>
         <comment>path for the forum</comment>
-        <translation>en/forum</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.cpp" line="274"/>
         <source>Opening files</source>
-        <translation>正在打开文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="20"/>
         <source>Polyphone Soundfont Editor</source>
-        <translation>Polyphone 音色库编辑器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="104"/>
         <source>  Settings</source>
         <extracomment>prefixed with 2 spaces</extracomment>
-        <translation>  设置</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="120"/>
         <source>  Documentation</source>
         <extracomment>prefixed with 2 spaces</extracomment>
-        <translation>  文档</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="mainwindow/mainwindow.ui" line="106"/>
+        <source></source>
+        <extracomment>prefixed with 2 spaces for each line</extracomment>
+        <translatorcomment>  New
+  soundfont</translatorcomment>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="139"/>
         <source>  New
   soundfont</source>
         <extracomment>prefixed with 2 spaces for each line</extracomment>
-        <translation>  新音色库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="172"/>
         <source>  Forum</source>
         <extracomment>prefixed with 2 spaces</extracomment>
-        <translation>  论坛</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="191"/>
         <source>Daily soundfonts</source>
-        <translation>每日音色库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="201"/>
         <source>  Online
   repository</source>
         <extracomment>prefixed with 2 spaces for each line</extracomment>
-        <translation>  在线仓库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="218"/>
         <source>Search a soundfont...</source>
-        <translation>搜索音色库...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="228"/>
         <source>  Open
   soundfont</source>
         <extracomment>prefixed with 2 spaces for each line</extracomment>
-        <translation>  打开音色库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/mainwindow.ui" line="248"/>
         <source>History</source>
-        <translation>历史</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2529,12 +2530,12 @@ repository</source>
     <message>
         <location filename="editor/modulator/modulatorcell.ui" line="144"/>
         <source>absolute value</source>
-        <translation type="unfinished">绝对值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatorcell.cpp" line="57"/>
         <source>Modulator</source>
-        <translation type="unfinished">调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatorcell.cpp" line="98"/>
@@ -2562,7 +2563,7 @@ default mod.</source>
     <message>
         <location filename="editor/modulator/modulatorcell.cpp" line="350"/>
         <source>dB</source>
-        <translation type="unfinished">分贝</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatorcell.cpp" line="358"/>
@@ -2578,7 +2579,6 @@ default mod.</source>
     <message>
         <location filename="editor/modulator/modulatorcell.cpp" line="370"/>
         <source>Add from:</source>
-        <oldsource>Add from: </oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2589,7 +2589,6 @@ default mod.</source>
     <message>
         <location filename="editor/modulator/modulatorcell.cpp" line="373"/>
         <source>To:</source>
-        <oldsource>To: </oldsource>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2599,7 +2598,7 @@ default mod.</source>
         <location filename="editor/modulator/modulatorcombodest.cpp" line="134"/>
         <location filename="editor/modulator/modulatorcombodest.cpp" line="163"/>
         <source>Modulator</source>
-        <translation type="unfinished">调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2607,17 +2606,17 @@ default mod.</source>
     <message>
         <location filename="editor/modulator/modulatorcombosrc.cpp" line="64"/>
         <source>Link</source>
-        <translation type="unfinished">链接</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatorcombosrc.cpp" line="93"/>
         <source>Link (invalid)</source>
-        <translation type="unfinished">链接(不合法)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatorcombosrc.cpp" line="96"/>
         <source>Modulator</source>
-        <translation type="unfinished">调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2625,17 +2624,17 @@ default mod.</source>
     <message>
         <location filename="editor/modulator/modulatoreditor.ui" line="74"/>
         <source>Add a modulator</source>
-        <translation type="unfinished">添加调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.ui" line="103"/>
         <source>Paste the copied modulators</source>
-        <translation type="unfinished">粘贴调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.ui" line="132"/>
         <source>Delete a modulator</source>
-        <translation type="unfinished">删除调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.ui" line="161"/>
@@ -2663,50 +2662,51 @@ default mod.</source>
     <message numerus="yes">
         <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
         <source>%n modulator(s):</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n modulator:</numerusform>
+            <numerusform>%n modulators:</numerusform>
         </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
         <source>Duplicate the selection toward...</source>
-        <translation type="unfinished">复制选择项到...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="345"/>
         <source>Copy the selected modulators</source>
-        <translation type="unfinished">复制选择的调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="350"/>
         <source>Duplicate modulators toward...</source>
-        <translation type="unfinished">复制调制器到...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="351"/>
         <source>Copy all modulators</source>
-        <translation type="unfinished">复制全部调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="628"/>
         <source>Forbidden action:</source>
-        <translation type="unfinished">禁止操作：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="638"/>
         <location filename="editor/modulator/modulatoreditor.cpp" line="647"/>
         <source>Warning</source>
-        <translation type="unfinished">警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="639"/>
         <source>offsets cannot be modulated in a preset.</source>
-        <translation type="unfinished">在预设中偏移量无法被调制。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="648"/>
         <source>%1 cannot be modulated in a preset.</source>
-        <translation type="unfinished">%1 无法在预设中被调制。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2714,7 +2714,7 @@ default mod.</source>
     <message>
         <location filename="core/output/not_supported/outputnotsupported.cpp" line="39"/>
         <source>This file format is not supported.</source>
-        <translation>该文件格式不被支持。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2722,24 +2722,24 @@ default mod.</source>
     <message>
         <location filename="core/output/sf2/outputsf2.cpp" line="45"/>
         <source>Please close file before overriding it.</source>
-        <translation>覆盖文件前先关闭文件。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sf2/outputsf2.cpp" line="73"/>
         <source>Couldn&apos;t delete file &quot;%1&quot;.</source>
         <oldsource>Couldn&apos;t delete file &quot;%1&quot;</oldsource>
-        <translation>无法删除文件 &quot;%1&quot;。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sf2/outputsf2.cpp" line="83"/>
         <source>Couldn&apos;t rename file &quot;%1&quot;.</source>
         <oldsource>Couldn&apos;t rename file &quot;%1&quot;</oldsource>
-        <translation>无法重命名文件 &quot;%1&quot;。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sf2/outputsf2.cpp" line="313"/>
         <source>Cannot create file &quot;%1&quot;</source>
-        <translation>无法创建文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2747,17 +2747,17 @@ default mod.</source>
     <message>
         <location filename="core/output/sf3/outputsf3.cpp" line="79"/>
         <source>Error during the sf3 conversion</source>
-        <translation>转换 SF3 时发生错误</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sf3/outputsf3.cpp" line="86"/>
         <source>Cannot create file &quot;%1&quot;</source>
-        <translation>无法创建文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/sf3/outputsf3.cpp" line="92"/>
         <source>Cannot read file &quot;%1&quot;</source>
-        <translation>无法读取文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2765,32 +2765,32 @@ default mod.</source>
     <message>
         <location filename="editor/pageinst.cpp" line="102"/>
         <source>Table</source>
-        <translation>表格</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageinst.cpp" line="103"/>
         <source>Ranges</source>
-        <translation>范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageinst.cpp" line="104"/>
         <source>Envelopes</source>
-        <translation>包络</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageinst.cpp" line="141"/>
         <source>Instrument not linked to a preset yet.</source>
-        <translation>乐器未链接到预设。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageinst.cpp" line="143"/>
         <source>Instrument linked to preset:</source>
-        <translation>乐器已链接的预设：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageinst.cpp" line="145"/>
         <source>Instrument linked to presets:</source>
-        <translation>乐器已链接的预设：</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2799,7 +2799,8 @@ default mod.</source>
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
         <source>%n element(s)</source>
         <translation>
-            <numerusform>%n元素</numerusform>
+            <numerusform>%n element</numerusform>
+            <numerusform>%n elements</numerusform>
         </translation>
     </message>
 </context>
@@ -2808,88 +2809,81 @@ default mod.</source>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="32"/>
         <source>Instruments</source>
-        <translation>乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="38"/>
         <source>Used</source>
-        <translation>已使用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="39"/>
         <source>Sample number</source>
-        <oldsource>Nombre d&apos;échantillons</oldsource>
-        <translation>样本数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="40"/>
         <source>Parameter number</source>
-        <oldsource>Nombre de paramètres</oldsource>
-        <translation>参数数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="41"/>
         <source>Modulator number</source>
-        <oldsource>Nombre de modulateurs</oldsource>
-        <translation>调制器数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="42"/>
         <source>Max key range</source>
-        <oldsource>Étendue totale (note)</oldsource>
-        <translation>最大音符范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="43"/>
         <source>Max velocity range</source>
-        <oldsource>Étendue totale (vélocité)</oldsource>
-        <translation>最大力度范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="44"/>
         <source>Attenuation</source>
-        <translation>衰减</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="45"/>
         <source>Loop playback</source>
-        <oldsource>Lecture en boucle</oldsource>
-        <translation>循环播放</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="46"/>
         <source>Chorus</source>
-        <translation>和声</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="47"/>
         <source>Reverb</source>
-        <oldsource>Reverbération</oldsource>
-        <translation>混响</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="100"/>
         <location filename="editor/overview/pageoverviewinst.cpp" line="286"/>
         <source>yes</source>
-        <translation>是</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="100"/>
         <location filename="editor/overview/pageoverviewinst.cpp" line="284"/>
         <source>no</source>
-        <translation>否</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="288"/>
         <source>yes, to the end</source>
         <translatorcomment>speaking about a loop mode</translatorcomment>
-        <translation>是，直到终点</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewinst.cpp" line="294"/>
         <source>several modes</source>
         <comment>speaking about loop modes</comment>
-        <translation>几个模式</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2897,59 +2891,52 @@ default mod.</source>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="32"/>
         <source>Presets</source>
-        <translation>预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="38"/>
         <source>Bank - Preset</source>
-        <oldsource>Banque - Preset</oldsource>
-        <translation>库-预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="39"/>
         <source>Instrument number</source>
-        <oldsource>Nombre d&apos;instruments</oldsource>
-        <translation>乐器编号</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="40"/>
         <source>Parameter number</source>
-        <oldsource>Nombre de paramètres</oldsource>
-        <translation>参数编号</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="41"/>
         <source>Modulator number</source>
-        <oldsource>Nombre de modulateurs</oldsource>
-        <translation>调制器编号</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="42"/>
         <source>Max key range</source>
-        <oldsource>Étendue totale (note)</oldsource>
-        <translation>最大音符范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="43"/>
         <source>Max velocity range</source>
-        <oldsource>Étendue totale (vélocité)</oldsource>
-        <translation>最大力度范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="44"/>
         <source>Attenuation</source>
-        <translation>衰减</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="45"/>
         <source>Chorus</source>
-        <translation>和声</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewprst.cpp" line="46"/>
         <source>Reverb</source>
-        <oldsource>Reverbération</oldsource>
-        <translation>混响</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2957,116 +2944,106 @@ default mod.</source>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="38"/>
         <source>Used</source>
-        <translation>已使用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="39"/>
         <source>Total
 duration</source>
-        <oldsource>Durée de la boucle</oldsource>
-        <translation>总
-时长</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="42"/>
         <source>Correction</source>
-        <translation>校正</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="40"/>
         <source>Loop
 duration</source>
-        <translation>循环
-时长</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="32"/>
         <source>Samples</source>
-        <translation>样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="41"/>
         <source>Root
 key</source>
-        <translation>根
-音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="43"/>
         <source>Sample
 type</source>
-        <oldsource>Échantillon lié</oldsource>
-        <translation>样本
-类型</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="44"/>
         <source>Linked
 sample</source>
-        <translation>链接的
-样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="45"/>
         <source>Sample
 rate</source>
-        <translation>采样率</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="94"/>
         <source>yes</source>
-        <translation>是</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="94"/>
         <source>no</source>
-        <translation>否</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="101"/>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="110"/>
         <source>s</source>
         <comment>unit for seconds</comment>
-        <translation>秒</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="133"/>
         <source>Invalid link</source>
-        <translation>不合法的链接</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="136"/>
         <source>Mono</source>
         <comment>opposite to stereo</comment>
-        <translation>单声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="139"/>
         <source>Stereo right</source>
-        <oldsource>Stereo droit</oldsource>
-        <translation>左声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="142"/>
         <source>Stereo left</source>
-        <oldsource>Stereo gauche</oldsource>
-        <translation>右声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="145"/>
         <source>Stereo non defined</source>
-        <oldsource>Stereo non défini</oldsource>
-        <translation>双声道未定义</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="165"/>
         <source>invalid</source>
-        <translation>不合法</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/overview/pageoverviewsmpl.cpp" line="172"/>
         <source>Hz</source>
-        <translation>赫兹</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3074,27 +3051,27 @@ rate</source>
     <message>
         <location filename="editor/pageprst.ui" line="166"/>
         <source>Bank</source>
-        <translation>库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageprst.ui" line="198"/>
         <source>Preset</source>
-        <translation>预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageprst.ui" line="237"/>
         <source>(percussion)</source>
-        <translation>(percussion)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageprst.cpp" line="96"/>
         <source>Table</source>
-        <translation>表格</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pageprst.cpp" line="97"/>
         <source>Ranges</source>
-        <translation>范围</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3102,164 +3079,160 @@ rate</source>
     <message>
         <location filename="editor/pagesf2.ui" line="72"/>
         <source>Title...</source>
-        <translation>标题...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="130"/>
         <source>Author...</source>
-        <translation>作者...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="183"/>
         <source>Date...</source>
-        <translation>日期...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="202"/>
         <source>Current date</source>
-        <translation>当前日期</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="234"/>
         <source>Product</source>
-        <translation>厂商</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="248"/>
         <source>Copyright</source>
-        <translation>版权</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="262"/>
         <source>Comments</source>
-        <translation>备注</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="327"/>
         <source>Soundfont version</source>
-        <translation>音色库版本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="363"/>
         <source>ROM name and version</source>
-        <translation>ROM 名称和版本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="399"/>
         <source>Sound engine</source>
-        <translation>音频引擎</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="435"/>
         <source>Editing software</source>
-        <translation>编辑软件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="538"/>
         <source>Presets</source>
-        <translation>预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="560"/>
         <location filename="editor/pagesf2.ui" line="681"/>
         <location filename="editor/pagesf2.ui" line="1009"/>
         <source>Details</source>
-        <translation>详细信息</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="659"/>
         <location filename="editor/pagesf2.ui" line="758"/>
         <source>Samples</source>
-        <translation>样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="744"/>
         <location filename="editor/pagesf2.ui" line="813"/>
         <location filename="editor/pagesf2.ui" line="876"/>
         <source>Number</source>
-        <translation>数字</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="772"/>
         <source>16 bits</source>
-        <translation>16 位</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="777"/>
         <source>24 bits</source>
-        <translation>24 位</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="806"/>
         <location filename="editor/pagesf2.ui" line="904"/>
         <source>Modulators</source>
-        <translation>调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="834"/>
         <location filename="editor/pagesf2.ui" line="869"/>
         <source>Parameters</source>
-        <translation>参数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.ui" line="987"/>
         <source>Instruments</source>
-        <translation>乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.cpp" line="105"/>
         <source>GB</source>
         <comment>giga byte</comment>
-        <translation>吉字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.cpp" line="110"/>
         <source>MB</source>
         <comment>mega byte</comment>
-        <translation>兆字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesf2.cpp" line="115"/>
         <source>kB</source>
         <comment>kilo byte</comment>
-        <translation>千字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
         <location filename="editor/pagesf2.cpp" line="247"/>
         <location filename="editor/pagesf2.cpp" line="257"/>
         <source>%1 (unused: %n)</source>
         <translation>
-            <numerusform>%1(未使用：%n)</numerusform>
+            <numerusform>%1 (unused: %n)</numerusform>
+            <numerusform>%1 (unused: %n)</numerusform>
         </translation>
     </message>
 </context>
 <context>
     <name>PageSmpl</name>
     <message>
-        <location filename="editor/pagesmpl.ui" line="626"/>
-        <source>Equalizer (±15 dB)</source>
-        <translation>均衡器(±15 分贝)</translation>
-    </message>
-    <message>
         <location filename="editor/pagesmpl.ui" line="320"/>
         <location filename="editor/pagesmpl.cpp" line="1083"/>
         <source>Play</source>
-        <translation>播放</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="260"/>
         <source>sinus</source>
-        <translation>正弦</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="253"/>
         <source>loop</source>
-        <translation>循环</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="267"/>
         <source>stereo</source>
-        <translation>双声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="403"/>
@@ -3269,120 +3242,125 @@ rate</source>
     <message>
         <location filename="editor/pagesmpl.ui" line="450"/>
         <source>Loop</source>
-        <translation>循环点</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="473"/>
         <source>Use the full length of the sample as loop</source>
-        <translation>全长循环</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="489"/>
         <source>Size</source>
-        <translation>长度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="548"/>
         <source>Sample rate</source>
-        <translation>采样率</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="433"/>
         <source>Type</source>
-        <translation>类型</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="440"/>
         <source>Link</source>
-        <translation>链接</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="204"/>
         <source>Use the estimated pitch and correction as values</source>
-        <translation>使用估计的音高校正音符值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.ui" line="585"/>
         <location filename="editor/pagesmpl.cpp" line="511"/>
         <location filename="editor/pagesmpl.cpp" line="1007"/>
         <source>Information</source>
-        <translation>信息</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/pagesmpl.ui" line="626"/>
+        <source>Equalizer (±15 dB)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="176"/>
         <location filename="editor/pagesmpl.cpp" line="181"/>
         <source>s</source>
         <comment>unit for seconds</comment>
-        <translation>秒</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="180"/>
         <location filename="editor/pagesmpl.cpp" line="183"/>
         <source>(min)</source>
         <comment>minimum</comment>
-        <translation>(最小)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="258"/>
         <location filename="editor/pagesmpl.cpp" line="641"/>
         <source>mono</source>
         <comment>opposite to stereo</comment>
-        <translation>单声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="268"/>
         <location filename="editor/pagesmpl.cpp" line="780"/>
         <source>right</source>
-        <translation>右</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="269"/>
         <location filename="editor/pagesmpl.cpp" line="781"/>
         <source>left</source>
-        <translation>左</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="270"/>
         <location filename="editor/pagesmpl.cpp" line="782"/>
         <source>link</source>
-        <translation>链接</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="308"/>
         <source>Sample not linked to an instrument yet.</source>
-        <translation>样本未链接到乐器。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="310"/>
         <source>Sample linked to instrument:</source>
-        <translation>样本已链接的乐器：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="312"/>
         <source>Sample linked to instruments:</source>
-        <translation>样本已链接的乐器：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="512"/>
         <location filename="editor/pagesmpl.cpp" line="1008"/>
         <source>Change successfully applied to the different samples</source>
-        <translation>更改已成功应用到其它样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="779"/>
         <location filename="editor/pagesmpl.cpp" line="804"/>
         <source>mono</source>
-        <translation>单声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="1077"/>
         <source>Stop</source>
-        <translation>停止</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="1097"/>
         <source>Warning</source>
-        <translation type="unfinished">警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/pagesmpl.cpp" line="1098"/>
@@ -3406,21 +3384,28 @@ rate</source>
     <message>
         <location filename="editor/pagetable.cpp" line="106"/>
         <source>Global</source>
-        <translation>全局</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="core/input/grandorgue/grandorguerank.cpp" line="138"/>
+        <location filename="core/input/grandorgue/grandorguestop.cpp" line="118"/>
+        <location filename="core/output/outputfactory.cpp" line="104"/>
+        <source>untitled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="core/output/outputfactory.cpp" line="117"/>
         <source>Save a soundfont</source>
-        <translation>保存音色库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sf2/inputsf2.h" line="35"/>
         <location filename="core/output/outputfactory.cpp" line="118"/>
         <source>Sf2 files</source>
-        <translation>SF2 文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/output/outputfactory.cpp" line="139"/>
@@ -3429,72 +3414,72 @@ rate</source>
         <location filename="core/sample/sound.cpp" line="78"/>
         <location filename="core/sample/sound.cpp" line="192"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="71"/>
         <source>Sample &quot;%1L&quot; already exists.&lt;br /&gt;Replace?</source>
-        <translation>样本 &quot;%1L&quot; 已存在。&lt;br/&gt;是否替换？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="76"/>
         <source>Sample &quot;%1R&quot; already exists.&lt;br /&gt;Replace?</source>
-        <translation>样本 &quot;%1R&quot; 已存在。&lt;br/&gt;是否替换？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="84"/>
         <source>Sample &quot;%1&quot; already exists.&lt;br /&gt;Replace?</source>
-        <translation>样本 &quot;%1&quot; 已存在。&lt;br/&gt;是否替换？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="97"/>
         <source>&amp;Replace</source>
-        <translation>替换(&amp;R)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="98"/>
         <source>R&amp;eplace all</source>
-        <translation>替换全部(&amp;E)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="99"/>
         <source>&amp;Duplicate</source>
-        <translation>创建副本(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="100"/>
         <source>D&amp;uplicate all</source>
-        <translation>全部创建副本(&amp;U)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="101"/>
         <source>&amp;Ignore</source>
-        <translation>忽略(&amp;I)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sampleloader.cpp" line="102"/>
         <source>I&amp;gnore all</source>
-        <translation>全部忽略(&amp;G)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/model/soundfont.cpp" line="46"/>
         <source>General</source>
-        <translation>通用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/model/soundfont.cpp" line="47"/>
         <source>Samples</source>
-        <translation>样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/model/soundfont.cpp" line="48"/>
         <source>Instruments</source>
-        <translation>乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/model/soundfont.cpp" line="49"/>
         <source>Presets</source>
-        <translation>预设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/sample/sound.cpp" line="71"/>
@@ -3509,189 +3494,182 @@ rate</source>
     <message>
         <location filename="core/sample/sound.cpp" line="79"/>
         <source>Cannot open file &quot;%1&quot;</source>
-        <translation>无法打开文件 &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <location filename="core/input/grandorgue/grandorguerank.cpp" line="138"/>
-        <location filename="core/input/grandorgue/grandorguestop.cpp" line="118"/>
-        <location filename="core/output/outputfactory.cpp" line="104"/>
-        <source>untitled</source>
-        <translation>未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphicslegenditem.cpp" line="117"/>
         <location filename="editor/graphics/graphicslegenditem2.cpp" line="66"/>
         <source>Key range:</source>
-        <translation>音符范围：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/graphics/graphicslegenditem.cpp" line="136"/>
         <location filename="editor/graphics/graphicslegenditem2.cpp" line="69"/>
         <source>Velocity range:</source>
-        <translation>力度范围：</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="dialogs/dialog_about.cpp" line="122"/>
+        <source>Created by</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="123"/>
-        <source>Created by</source>
-        <translation>作者</translation>
+        <source>Contributors</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="dialogs/dialog_about.cpp" line="124"/>
-        <source>Contributors</source>
-        <translation>贡献者</translation>
-    </message>
-    <message>
-        <location filename="dialogs/dialog_about.cpp" line="125"/>
         <source>Translated by</source>
-        <translation>翻译者</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="dialogs/dialog_about.cpp" line="167"/>
+        <location filename="dialogs/dialog_about.cpp" line="166"/>
         <source>Icons</source>
-        <translation>图标</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfontinformation.cpp" line="46"/>
         <source>Unknown author</source>
-        <translation>未知作者</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="64"/>
         <location filename="context/keynamemanager.cpp" line="82"/>
         <source>C</source>
         <comment>key name</comment>
-        <translation>C</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="65"/>
         <source>D♭</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="66"/>
         <location filename="context/keynamemanager.cpp" line="84"/>
         <source>D</source>
         <comment>key name</comment>
-        <translation>D</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="67"/>
         <source>E♭</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="68"/>
         <location filename="context/keynamemanager.cpp" line="86"/>
         <source>E</source>
         <comment>key name</comment>
-        <translation>E</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="69"/>
         <location filename="context/keynamemanager.cpp" line="87"/>
         <source>F</source>
         <comment>key name</comment>
-        <translation>F</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="70"/>
         <source>G♭</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="71"/>
         <location filename="context/keynamemanager.cpp" line="89"/>
         <source>G</source>
         <comment>key name</comment>
-        <translation>G</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="72"/>
         <source>A♭</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="73"/>
         <location filename="context/keynamemanager.cpp" line="91"/>
         <source>A</source>
         <comment>key name</comment>
-        <translation>A</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="74"/>
         <source>B♭</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="75"/>
         <location filename="context/keynamemanager.cpp" line="93"/>
         <source>B</source>
         <comment>key name</comment>
-        <translation>B</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="83"/>
         <source>C♯</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="85"/>
         <source>D♯</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="88"/>
         <source>F♯</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="90"/>
         <source>G♯</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/keynamemanager.cpp" line="92"/>
         <source>A♯</source>
         <comment>key name</comment>
-        <translation></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/soundfontdownloaddata.cpp" line="55"/>
         <source>bytes</source>
-        <translation type="unfinished">字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/soundfontdownloaddata.cpp" line="57"/>
         <source>kB</source>
         <comment>kilobytes</comment>
-        <translation type="unfinished">千字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/soundfontdownloaddata.cpp" line="59"/>
         <source>MB</source>
         <comment>megabytes</comment>
-        <translation type="unfinished">兆字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/soundfontdownloaddata.cpp" line="61"/>
         <source>GB</source>
         <comment>gigabytes</comment>
-        <translation type="unfinished">吉字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/soundfontdownloaddata.cpp" line="62"/>
         <source>TB</source>
         <comment>terabytes</comment>
-        <translation type="unfinished">太字节</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/grandorgue/inputgrandorgue.h" line="35"/>
@@ -3701,22 +3679,22 @@ rate</source>
     <message>
         <location filename="core/input/inputfactory.cpp" line="118"/>
         <source>All</source>
-        <translation type="unfinished">全部</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sf3/inputsf3.h" line="35"/>
         <source>Sf3 files</source>
-        <translation type="unfinished">SF3 文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sfark/inputsfark.h" line="35"/>
         <source>sfArk archives</source>
-        <translation type="unfinished">sfArk 压缩文档</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="core/input/sfz/inputsfz.h" line="35"/>
         <source>Sfz files</source>
-        <translation type="unfinished">SFZ 文件</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3724,12 +3702,12 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="77"/>
         <source>acoustic instrument</source>
-        <translation>原声乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="78"/>
         <source>electronic instrument</source>
-        <translation>电子乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="79"/>
@@ -3739,52 +3717,52 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="80"/>
         <source>additive synthesis</source>
-        <translation>加法合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="81"/>
         <source>subtrative synthesis</source>
-        <translation>减法合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="82"/>
         <source>wavetable synthesis</source>
-        <translation>波表合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="83"/>
         <source>model synthesis</source>
-        <translation>模型合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="84"/>
         <source>FM synthesis</source>
-        <translation>调频合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="85"/>
         <source>vector synthesis</source>
-        <translation>矢量合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="86"/>
         <source>granular synthesis</source>
-        <translation>粒子合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="87"/>
         <source>other synthesis</source>
-        <translation>其它合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="90"/>
         <source>high</source>
-        <translation>高</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="91"/>
         <source>low</source>
-        <translation>低</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="92"/>
@@ -3799,22 +3777,22 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="94"/>
         <source>bright</source>
-        <translation>明亮</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="95"/>
         <source>dark</source>
-        <translation>阴暗</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="96"/>
         <source>warm</source>
-        <translation>温和</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="97"/>
         <source>cold</source>
-        <translation>冷酷</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="98"/>
@@ -3829,12 +3807,12 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="100"/>
         <source>hard</source>
-        <translation>坚硬</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="101"/>
         <source>soft</source>
-        <translation>柔软</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="102"/>
@@ -3844,7 +3822,7 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="103"/>
         <source>detuned</source>
-        <translation>失谐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="104"/>
@@ -3854,12 +3832,12 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="105"/>
         <source>noisy</source>
-        <translation>嘈杂</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="106"/>
         <source>metallic</source>
-        <translation>金属</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="107"/>
@@ -3894,7 +3872,7 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="115"/>
         <source>percussive</source>
-        <translation>打击乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="116"/>
@@ -3909,7 +3887,7 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="118"/>
         <source>echoing</source>
-        <translation>回音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="119"/>
@@ -3929,7 +3907,7 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="122"/>
         <source>chord</source>
-        <translation>和声</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="123"/>
@@ -3944,7 +3922,7 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="125"/>
         <source>arpeggiated</source>
-        <translation>琵音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="126"/>
@@ -3954,33 +3932,33 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="127"/>
         <source>complex</source>
-        <translation>复杂</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="128"/>
         <source>randomized</source>
-        <translation>随机化</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="131"/>
         <source>classic music</source>
-        <translation>古典</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="132"/>
         <source>electronic music</source>
-        <translation>电子</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="133"/>
         <source>trance</source>
-        <translation>迷幻</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="134"/>
         <location filename="repository/repositorymanager.cpp" line="135"/>
         <source>ambient music</source>
-        <translation>氛围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="136"/>
@@ -3990,7 +3968,7 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="137"/>
         <source>techno / electro</source>
-        <translation>科技/电子</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="138"/>
@@ -4000,12 +3978,12 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="139"/>
         <source>industrial</source>
-        <translation>工业</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="140"/>
         <source>experimental</source>
-        <translation>实验</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="141"/>
@@ -4025,128 +4003,128 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="144"/>
         <source>pop / rock</source>
-        <translation>流行/摇滚</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="145"/>
         <source>metal music</source>
-        <translation>金属</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="146"/>
         <source>hiphop / rap</source>
-        <translation>嘻哈/说唱</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="147"/>
         <source>jazz / swing</source>
-        <translation>爵士/摇摆</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="148"/>
         <source>folk / country</source>
-        <translation>乡村</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="149"/>
         <location filename="repository/repositorymanager.cpp" line="150"/>
         <source>ethnic / world</source>
-        <translation>民族/世界</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="167"/>
         <source>public domain</source>
-        <translation>公有领域</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="168"/>
         <source>give credit</source>
-        <translation>署名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="169"/>
         <source>give credit, don&apos;t distribute with more restrictions</source>
-        <translation>署名，不允许分发时附带更多限制</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="170"/>
         <source>don&apos;t distribute a modified version</source>
-        <translation>不允许分发修改版</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="171"/>
         <source>personal use</source>
-        <translation>个人使用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="172"/>
         <source>personal use, don&apos;t distribute with more restrictions</source>
-        <translation>个人使用，不允许分发时附带更多限制</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="173"/>
         <source>personal use, don&apos;t distribute a modified version</source>
-        <translation>个人使用，不允许分发修改版</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="384"/>
         <source>piano</source>
-        <translation>钢琴</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="387"/>
         <source>organ</source>
-        <translation>风琴</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="390"/>
         <source>synthesizer</source>
-        <translation>合成器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="393"/>
         <source>harpsichord</source>
-        <translation>拨弦键琴</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="396"/>
         <source>guitar</source>
-        <translation>吉他</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="399"/>
         <source>bass</source>
-        <translation>低音乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="402"/>
         <source>plucked strings</source>
-        <translation>拨弦乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="405"/>
         <source>bowed strings</source>
-        <translation>弓弦乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="408"/>
         <source>flute</source>
-        <translation>长笛</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="411"/>
         <source>reed</source>
-        <translation>簧管</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="414"/>
         <source>brass</source>
-        <translation>铜管</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="417"/>
         <source>vocal</source>
-        <translation>人声</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="420"/>
@@ -4156,57 +4134,57 @@ rate</source>
     <message>
         <location filename="repository/repositorymanager.cpp" line="423"/>
         <source>melodic percussion</source>
-        <translation>旋律打击乐</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="426"/>
         <source>sound effect</source>
-        <translation>音效</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="429"/>
         <source>soundscape</source>
-        <translation>环境音效</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="432"/>
         <source>loop / rythm</source>
-        <translation>循环/韵律</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="435"/>
         <source>instrument set</source>
-        <translation>乐器集合</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="438"/>
         <source>unclassifiable</source>
-        <translation>未分类</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="445"/>
         <source>Category %1</source>
-        <translation>分类 %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="473"/>
         <source>Please wait...</source>
-        <translation>请稍后...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="476"/>
         <source>Your account has been banned.</source>
-        <translation>你的账户已被封禁。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="481"/>
         <source>A Premium account allows you to browse and download all soundfonts available online.</source>
-        <translation>高级账户允许你浏览和下载所有在线可用的音色库。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/repositorymanager.cpp" line="490"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4215,7 +4193,7 @@ rate</source>
         <location filename="repository/daily/showsoundfonts.ui" line="217"/>
         <source>Oops! Cannot
 download the list</source>
-        <translation>无法下载列表</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4223,103 +4201,104 @@ download the list</source>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="172"/>
         <source>Category</source>
-        <translation>目录</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="188"/>
         <source>License</source>
-        <translation>许可证</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="204"/>
         <source>Sample source</source>
-        <translation>样本来源</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="220"/>
         <source>Timbre</source>
-        <translation>乐器音质</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="236"/>
         <source>Articulation</source>
-        <translation>发音清晰度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="252"/>
         <source>Genre</source>
-        <translation>风格</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="268"/>
         <source>MIDI standard</source>
-        <translation>MIDI 标准</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="284"/>
         <source>Tags</source>
-        <translation>标签</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="337"/>
         <source>Search a soundfont...</source>
-        <translation>搜索音色库...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="387"/>
         <source>Date</source>
-        <translation>日期</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="392"/>
         <source>Downloads</source>
-        <translation>下载</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="397"/>
         <source>Rating score</source>
-        <translation>评分</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="402"/>
         <source>Title (A→Z)</source>
-        <translation>标题(A→Z)</translation>
+        <oldsource>Title (A?Z)</oldsource>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="458"/>
         <source>Filters</source>
-        <translation>筛选</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="487"/>
         <source>Reset</source>
-        <translation>重设</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="506"/>
         <source>Subscribe to a Premium account to get all the features!</source>
-        <translation>订阅高级账户获取所有功能!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="528"/>
         <source>No results</source>
-        <translation>无结果</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.ui" line="609"/>
         <source>Oops! Cannot
 download the list</source>
-        <translation>无法下载列表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.cpp" line="142"/>
         <source>commercial use</source>
-        <translation>商业使用</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/browser/soundfontbrowser.cpp" line="143"/>
         <source>share after editing</source>
-        <translation>二次编辑后共享</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4327,7 +4306,7 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/viewer/soundfontcomment.cpp" line="75"/>
         <source>No comments.</source>
-        <translation>无评论。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4335,7 +4314,7 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/viewer/soundfontdownloadcell.ui" line="61"/>
         <source>Download</source>
-        <translation>下载</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4343,12 +4322,12 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorcenter.ui" line="42"/>
         <source>Description</source>
-        <translation type="unfinished">描述</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorcenter.ui" line="112"/>
         <source>Files</source>
-        <translation type="unfinished">文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorcenter.ui" line="128"/>
@@ -4361,27 +4340,27 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="36"/>
         <source>Timbre</source>
-        <translation type="unfinished">乐器音质</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="62"/>
         <source>Genre</source>
-        <translation type="unfinished">风格</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="94"/>
         <source>Articulation</source>
-        <translation type="unfinished">发音清晰度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="113"/>
         <source>Tags</source>
-        <translation type="unfinished">标签</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="177"/>
         <source>Category</source>
-        <translation type="unfinished">目录</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="184"/>
@@ -4391,12 +4370,12 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="197"/>
         <source>Sample source</source>
-        <translation type="unfinished">样本来源</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.ui" line="245"/>
         <source>MIDI standard</source>
-        <translation type="unfinished">MIDI 标准</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditorleft.cpp" line="46"/>
@@ -4423,7 +4402,7 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/editor/soundfonteditortop.ui" line="38"/>
         <source>Title...</source>
-        <translation type="unfinished">标题...</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4436,7 +4415,7 @@ download the list</source>
     <message>
         <location filename="repository/soundfont/editor/soundfontfilecell.ui" line="48"/>
         <source>Title...</source>
-        <translation type="unfinished">标题...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/editor/soundfontfilecell.ui" line="58"/>
@@ -4455,7 +4434,7 @@ download the list</source>
         <location filename="repository/soundfont/soundfontviewer.ui" line="354"/>
         <source>Oops! Cannot
 download content</source>
-        <translation>无法下载列表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/soundfontviewer.ui" line="500"/>
@@ -4473,22 +4452,22 @@ download content</source>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewercenter.ui" line="51"/>
         <source>Description</source>
-        <translation type="unfinished">描述</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewercenter.ui" line="67"/>
         <source>No description.</source>
-        <translation type="unfinished">无描述。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewercenter.ui" line="93"/>
         <source>Downloads</source>
-        <translation type="unfinished">下载</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewercenter.ui" line="129"/>
         <source>Comments</source>
-        <translation type="unfinished">备注</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4496,37 +4475,37 @@ download content</source>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="161"/>
         <source>Category</source>
-        <translation type="unfinished">目录</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="177"/>
         <source>Sample source</source>
-        <translation type="unfinished">样本来源</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="193"/>
         <source>Timbre</source>
-        <translation type="unfinished">乐器音质</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="209"/>
         <source>Articulation</source>
-        <translation type="unfinished">发音清晰度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="225"/>
         <source>Genre</source>
-        <translation type="unfinished">风格</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="241"/>
         <source>MIDI standard</source>
-        <translation type="unfinished">MIDI 标准</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/soundfont/viewer/soundfontviewerleft.ui" line="257"/>
         <source>Tags</source>
-        <translation type="unfinished">标签</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4534,7 +4513,7 @@ download content</source>
     <message>
         <location filename="editor/widgets/tableheaderview.cpp" line="47"/>
         <source>mute</source>
-        <translation>静音</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/widgets/tableheaderview.cpp" line="52"/>
@@ -4549,7 +4528,7 @@ download content</source>
     <message>
         <location filename="editor/widgets/tableheaderview.cpp" line="55"/>
         <source>unmute all</source>
-        <translation>取消全部静音</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4575,57 +4554,57 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="context/thememanager.cpp" line="57"/>
         <source>Custom</source>
-        <translation>自定义</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="376"/>
         <source>Default</source>
-        <translation>默认</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="396"/>
         <source>Gnome</source>
-        <translation>Gnome</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="409"/>
         <source>Dark, blue</source>
-        <translation>暗蓝</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="422"/>
         <source>Dark, orange</source>
-        <translation>暗橙</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="435"/>
         <source>Dark, green</source>
-        <translation>暗绿</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="448"/>
         <source>Dark, yellow</source>
-        <translation>暗黄</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="461"/>
         <source>Aqua</source>
-        <translation>水绿</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="474"/>
         <source>Spring</source>
-        <translation>Spring</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="487"/>
         <source>Windows 10</source>
-        <translation>Windows 10</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="500"/>
         <source>Ubuntu</source>
-        <translation>Ubuntu</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="context/thememanager.cpp" line="513"/>
@@ -4641,15 +4620,15 @@ Other soundfont editors might display other units.</source>
 <context>
     <name>ToolAutoDistribution</name>
     <message>
-        <location filename="editor/tools/auto_distribution/toolautodistribution.h" line="45"/>
-        <source>Fast editing</source>
-        <translation>快速编辑</translation>
-    </message>
-    <message>
         <location filename="editor/tools/auto_distribution/toolautodistribution.h" line="60"/>
         <source>Sample auto-positioning</source>
         <oldsource>Automatically link the samples</oldsource>
-        <translation type="unfinished">自动链接样本</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/auto_distribution/toolautodistribution.h" line="45"/>
+        <source>Fast editing</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4657,27 +4636,27 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/auto_loop/toolautoloop.cpp" line="75"/>
         <source>Failed to loop sample &quot;%1&quot;.</source>
-        <translation>无法自动循环样本 &quot;%1&quot;。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/auto_loop/toolautoloop.cpp" line="78"/>
         <source>The following samples couldn&apos;t be looped:</source>
-        <translation>下列样本无法循环：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/auto_loop/toolautoloop.cpp" line="83"/>
         <source>Possible reasons: too short or too turbulent.</source>
-        <translation>可能原因：样本太短或太混乱。</translation>
-    </message>
-    <message>
-        <location filename="editor/tools/auto_loop/toolautoloop.h" line="47"/>
-        <source>Sample processing</source>
-        <translation>样本处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/auto_loop/toolautoloop.h" line="65"/>
         <source>Auto loop</source>
-        <translation>自动循环</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/auto_loop/toolautoloop.h" line="47"/>
+        <source>Sample processing</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4685,17 +4664,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/balance_adjustment/toolbalanceadjustment.cpp" line="121"/>
         <source>This tool cannot be used with mono samples:</source>
-        <translation>该工具无法用于单声道样本:</translation>
-    </message>
-    <message>
-        <location filename="editor/tools/balance_adjustment/toolbalanceadjustment.h" line="47"/>
-        <source>Stereo samples</source>
-        <translation>双声道样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/balance_adjustment/toolbalanceadjustment.h" line="65"/>
         <source>Balance adjustement</source>
-        <translation>平衡调整</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/balance_adjustment/toolbalanceadjustment.h" line="47"/>
+        <source>Stereo samples</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4703,12 +4682,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning.h" line="45"/>
         <source>Fast editing</source>
-        <translation>快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning.h" line="60"/>
         <source>Detune</source>
-        <translation>失谐</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4721,27 +4700,27 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning_gui.ui" line="29"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning_gui.ui" line="97"/>
         <source>Division to the next octave</source>
-        <translation>划分到下个八度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning_gui.ui" line="58"/>
         <source>The algebraic sign determines the tuning direction.</source>
-        <translation>代数符号决定调音方向。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning_gui.cpp" line="50"/>
         <source>Number of beats per second</source>
-        <translation>每秒节拍数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/celeste_tuning/toolcelestetuning_gui.cpp" line="50"/>
         <source>key</source>
-        <translation>音符</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4749,12 +4728,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation.h" line="46"/>
         <source>Fast editing</source>
-        <translation>快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation.h" line="64"/>
         <source>Change attenuations</source>
-        <translation>更改衰减</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4762,17 +4741,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation_gui.ui" line="83"/>
         <source>Desired value</source>
-        <translation>期望值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation_gui.ui" line="125"/>
         <source>Possible offset</source>
-        <translation>可偏移量</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation_gui.ui" line="112"/>
         <source>Attenuation range</source>
-        <translation>衰减范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation_gui.ui" line="55"/>
@@ -4782,12 +4761,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation_gui.ui" line="35"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_attenuation/toolchangeattenuation_gui.ui" line="96"/>
         <source> dB</source>
-        <translation> 分贝</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4795,12 +4774,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume.h" line="46"/>
         <source>Sample processing</source>
-        <translation>样本处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume.h" line="61"/>
         <source>Change volume</source>
-        <translation>音量调整</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4808,7 +4787,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="56"/>
         <source>Add</source>
-        <translation>增加</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="108"/>
@@ -4818,27 +4797,27 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="36"/>
         <source> dB</source>
-        <translation> 分贝</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="79"/>
         <source>Multiply</source>
-        <translation>放大倍数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="49"/>
         <source>Normalize</source>
-        <translation>规格化</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="88"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/change_volume/toolchangevolume_gui.ui" line="66"/>
         <source> %</source>
-        <translation> %</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4846,17 +4825,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/chords/toolchords.cpp" line="61"/>
         <source>The instrument contains no samples.</source>
-        <translation>该乐器不包含样本。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords.h" line="48"/>
         <source>Transformation</source>
-        <translation>变换</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords.h" line="63"/>
         <source>Create chords</source>
-        <translation>创建和弦</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4864,67 +4843,67 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="25"/>
         <source>Instrument name:</source>
-        <translation>乐器名称：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="39"/>
         <source>Sample creation:</source>
-        <translation>样本创建物：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="47"/>
         <source>for every key</source>
-        <translation>每个音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="52"/>
         <source>every 3 keys</source>
-        <translation>每3个音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="57"/>
         <source>every 6 keys</source>
-        <translation>每6个音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="65"/>
         <source>Auto loop</source>
-        <translation>自动循环</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="75"/>
         <source>Stereo</source>
-        <translation>双声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="90"/>
         <source>Chord</source>
-        <translation>和声</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="115"/>
         <source>Seventh</source>
-        <translation>七度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="128"/>
         <source>Ninth</source>
-        <translation>九度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="141"/>
         <source>Third</source>
-        <translation>三度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="179"/>
         <source>Root key</source>
-        <translation>根音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="192"/>
         <source>Fifth</source>
-        <translation>五度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="231"/>
@@ -4933,31 +4912,31 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="364"/>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="419"/>
         <source>no</source>
-        <translation>否</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="236"/>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="306"/>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="374"/>
         <source>major</source>
-        <translation>大调</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="241"/>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="311"/>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="369"/>
         <source>minor</source>
-        <translation>小调</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="261"/>
         <source>yes</source>
-        <translation>是</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="350"/>
         <source>Inversion number</source>
-        <translation>倒数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="379"/>
@@ -4978,7 +4957,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="687"/>
         <source>Octave</source>
-        <translation>八度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="719"/>
@@ -4988,7 +4967,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/chords/toolchords_gui.ui" line="699"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4997,32 +4976,33 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
         <source>%1 and %2 have been deleted.</source>
         <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
-        <translatorcomment>[X个样本]和[Y个乐器]已被删除。</translatorcomment>
-        <translation>%1和%2已被删除。</translation>
+        <translation>%1 and %2 have been deleted.</translation>
     </message>
     <message numerus="yes">
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
         <source>%n sample(s)</source>
         <translation>
-            <numerusform>%n个样本</numerusform>
+            <numerusform>%n sample</numerusform>
+            <numerusform>%n samples</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
         <source>%n instrument(s)</source>
         <translation>
-            <numerusform>%n个乐器</numerusform>
+            <numerusform>%n instrument</numerusform>
+            <numerusform>%n instruments</numerusform>
         </translation>
-    </message>
-    <message>
-        <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
-        <source>Clean up</source>
-        <translation>清理</translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="69"/>
         <source>Remove unused elements</source>
-        <translation>移除未使用的元素</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
+        <source>Clean up</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5030,7 +5010,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/default_mod/tooldefaultmod.h" line="45"/>
         <source>Modulators</source>
-        <translation type="unfinished">调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/default_mod/tooldefaultmod.h" line="60"/>
@@ -5061,7 +5041,7 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/default_mod/tooldefaultmod_gui.ui" line="88"/>
         <source>&amp;Cancel</source>
         <oldsource>Cancel</oldsource>
-        <translation type="unfinished">取消</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5069,22 +5049,22 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication.cpp" line="84"/>
         <source>An instrument comprising no samples is not compatible with this tool:</source>
-        <translation>不含样本的乐器与该工具不兼容：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication.cpp" line="85"/>
         <source>A preset comprising no instruments is not compatible with this tool:</source>
-        <translation>不包含乐器的预设与该工具不兼容：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication.h" line="45"/>
         <source>Transformation</source>
-        <translation>变换</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication.h" line="63"/>
         <source>Division duplication</source>
-        <translation>复制分层</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5092,7 +5072,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication_gui.ui" line="30"/>
         <source>A division for each velocity range</source>
-        <translation>为每个力度范围创建分层</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication_gui.ui" line="143"/>
@@ -5102,12 +5082,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication_gui.ui" line="123"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/division_duplication/tooldivisionduplication_gui.ui" line="20"/>
         <source>A division for each key</source>
-        <translation>为每个音符创建分层</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5115,22 +5095,22 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand.cpp" line="118"/>
         <source>Couldn&apos;t start the command.</source>
-        <translation>无法启动命令。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand.cpp" line="121"/>
         <source>The execution of the command ended with an error.</source>
-        <translation>命令的执行以含错误的状态结束。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand.h" line="48"/>
         <source>Sample processing</source>
-        <translation>样本处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand.h" line="66"/>
         <source>External command</source>
-        <translation>外部命令</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5138,22 +5118,22 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="80"/>
         <source>Command</source>
-        <translation>命令</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="87"/>
         <source>History</source>
-        <translation>历史</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="94"/>
         <source>Authorize stereo editing</source>
-        <translation>允许编辑双声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="118"/>
         <source>Replace sample information if possible</source>
-        <translation>如可能则替换样本信息</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="150"/>
@@ -5163,33 +5143,33 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="130"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.ui" line="50"/>
         <source>Command examples:</source>
-        <translation>命令示例：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.cpp" line="99"/>
         <source>Executable file</source>
-        <translation>可执行文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.cpp" line="116"/>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.cpp" line="123"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.cpp" line="116"/>
         <source>You must enter a command with at least {wav} as argument.</source>
-        <translation>输入的命令需要包含{wav}参数。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/external_command/toolexternalcommand_gui.cpp" line="123"/>
         <source>The command must contain the argument {wav}.</source>
-        <translation>命令必须包含参数{wav}。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5197,12 +5177,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl.h" line="46"/>
         <source>Sample processing</source>
-        <translation type="unfinished">样本处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl.h" line="61"/>
         <source>Fast editing</source>
-        <translation type="unfinished">快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5210,7 +5190,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl_gui.ui" line="22"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl_gui.ui" line="42"/>
@@ -5220,17 +5200,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl_gui.ui" line="67"/>
         <source>Add</source>
-        <translation type="unfinished">增加</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl_gui.ui" line="74"/>
         <source>Multiply</source>
-        <translation type="unfinished">放大倍数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/fast_edit_smpl/toolfasteditsmpl_gui.ui" line="84"/>
         <source>Parameter</source>
-        <translation type="unfinished">参数</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5238,12 +5218,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/frequency_filter/toolfrequencyfilter.h" line="46"/>
         <source>Sample processing</source>
-        <translation>样本处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_filter/toolfrequencyfilter.h" line="61"/>
         <source>Filter frequencies</source>
-        <translation>频率滤波</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5256,13 +5236,13 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/frequency_filter/toolfrequencyfilter_gui.ui" line="81"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_filter/toolfrequencyfilter_gui.ui" line="32"/>
         <source>Mark with red color where you want to cut the frequencies:</source>
         <oldsource>Put in red the part of frequencies to filter:</oldsource>
-        <translation>将要剪掉的频率置于红色部分：</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5270,48 +5250,48 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="54"/>
         <source>Sample</source>
-        <translation>样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="54"/>
         <source>Peak</source>
-        <translation>峰值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="55"/>
         <source>Intensity</source>
-        <translation>强度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="55"/>
         <source>Frequency</source>
-        <translation>频率</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="56"/>
         <source>Key</source>
-        <translation>音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="56"/>
         <source>Correction</source>
-        <translation>校正</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.cpp" line="81"/>
         <source>Success</source>
-        <translation>成功</translation>
-    </message>
-    <message>
-        <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.h" line="45"/>
-        <source>Analyze</source>
-        <translation>分析</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.h" line="60"/>
         <source>Show peak frequencies</source>
         <oldsource>Show peak frequency</oldsource>
-        <translation type="unfinished">显示峰值频率</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/frequency_peaks/toolfrequencypeaks.h" line="45"/>
+        <source>Analyze</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5320,58 +5300,58 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.ui" line="26"/>
         <source>&amp;Export</source>
         <oldsource>Export</oldsource>
-        <translation type="unfinished">导出</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.ui" line="33"/>
         <source>&amp;Close</source>
         <oldsource>Close</oldsource>
-        <translation type="unfinished">关闭</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="84"/>
         <source>Sample</source>
-        <translation>样本</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="85"/>
         <source>Peak</source>
-        <translation>峰值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="86"/>
         <source>Intensity</source>
-        <translation>强度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="87"/>
         <source>Frequency</source>
-        <translation>频率</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="88"/>
         <source>Key</source>
-        <translation>音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="89"/>
         <source>Correction</source>
-        <translation>校正</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="151"/>
         <source>Hz</source>
-        <translation>赫兹</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="175"/>
         <source>Export peak frequency</source>
-        <translation>导出峰值频率</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/frequency_peaks/toolfrequencypeaks_gui.cpp" line="176"/>
         <source>Csv file</source>
-        <translation>CSV文件</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5379,12 +5359,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings.h" line="46"/>
         <source>Fast editing</source>
-        <translation>快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings.h" line="64"/>
         <source>Key-based configuration</source>
-        <translation>基于音符的配置</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5392,77 +5372,77 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="27"/>
         <source>Minimum</source>
-        <translation>最小值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="35"/>
         <source>Addition</source>
-        <translation>加</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="40"/>
         <source>Multiplication</source>
-        <translation>乘</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="45"/>
         <source>Replacement</source>
-        <translation>替换</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="76"/>
         <source>Parameter</source>
-        <translation>参数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="96"/>
         <source>Pattern</source>
-        <translation>模式</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="119"/>
         <source>Maximum</source>
-        <translation>最大值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="126"/>
         <source>Modification</source>
-        <translation>修改方式</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="153"/>
         <source>Manual</source>
-        <translation>手动</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="158"/>
         <source>Linear ascending</source>
-        <translation>线性上升</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="163"/>
         <source>Linear descending</source>
-        <translation>线性下降</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="168"/>
         <source>Exponential ascending</source>
-        <translation>指数上升</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="173"/>
         <source>Exponential descending</source>
-        <translation>指数下降</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="178"/>
         <source>Random</source>
-        <translation>随机</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="249"/>
         <source>Apply to a velocity range</source>
-        <translation>应用到力度范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="278"/>
@@ -5472,30 +5452,30 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.ui" line="271"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.cpp" line="243"/>
         <source>Stiffness</source>
-        <translation>硬度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/global_settings/toolglobalsettings_gui.cpp" line="248"/>
         <source>Distribution</source>
-        <translation>分布</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ToolLinkSample</name>
     <message>
-        <location filename="editor/tools/link_sample/toollinksample.h" line="49"/>
-        <source>Stereo samples</source>
-        <translation>双声道样本</translation>
-    </message>
-    <message>
         <location filename="editor/tools/link_sample/toollinksample.h" line="67"/>
         <source>Find a link</source>
-        <translation>搜索链接</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/link_sample/toollinksample.h" line="49"/>
+        <source>Stereo samples</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5503,17 +5483,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation.cpp" line="60"/>
         <source>The instrument contains no samples.</source>
-        <translation>该乐器不包含样本。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation.h" line="48"/>
         <source>Transformation</source>
-        <translation>变换</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation.h" line="63"/>
         <source>Mixture creation</source>
-        <translation>创建混合音栓</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5521,127 +5501,127 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="25"/>
         <source>Name of the mixture:</source>
-        <translation>名称：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="39"/>
         <source>Sample creation:</source>
-        <translation>创建样本：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="47"/>
         <source>for every key</source>
-        <translation>每个音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="52"/>
         <source>every 3 keys</source>
-        <translation>每 3 个音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="57"/>
         <source>every 6 keys</source>
-        <translation>每 6 个音符</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="65"/>
         <source>Auto loop</source>
-        <translation>自动循环</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="75"/>
         <source>Stereo</source>
-        <translation>双声道</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="89"/>
         <source>Divisions</source>
-        <translation>分层</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="242"/>
         <source>Key range</source>
-        <translation>音符范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="265"/>
         <source>Ranks</source>
-        <translation>管列</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="338"/>
         <source>Type</source>
-        <translation>类型</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="346"/>
         <source>octave</source>
-        <translation>八度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="351"/>
         <source>fifth</source>
-        <translation>五度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="356"/>
         <source>third</source>
-        <translation>三度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="361"/>
         <source>seventh</source>
-        <translation>七度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="366"/>
         <source>ninth</source>
-        <translation>九度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="371"/>
         <source>eleventh</source>
-        <translation>十一度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="376"/>
         <source>thirteenth</source>
-        <translation>十三度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="381"/>
         <source>fifteenth</source>
-        <translation>十五度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="386"/>
         <source>seventeenth</source>
-        <translation>十七度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="391"/>
         <source>nineteenth</source>
-        <translation>十九度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="396"/>
         <source>twenty-first</source>
-        <translation>二十一度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="401"/>
         <source>twenty-third</source>
-        <translation>二十三度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="406"/>
         <source>twenty-fifth</source>
-        <translation>二十五度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="411"/>
         <source>twenty-seventh</source>
-        <translation>二十七度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="498"/>
@@ -5651,23 +5631,23 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.ui" line="478"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.cpp" line="535"/>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.cpp" line="551"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.cpp" line="535"/>
         <source>The instrument name must be provided.</source>
-        <translation>该乐器需要名称。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/mixture_creation/toolmixturecreation_gui.cpp" line="551"/>
         <source>At least one rank must be specified.</source>
-        <translation>至少指定一个管列。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5675,12 +5655,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/monitor/toolmonitor.h" line="45"/>
         <source>Analyze</source>
-        <translation>分析</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/monitor/toolmonitor.h" line="57"/>
         <source>Display parameters</source>
-        <translation>显示参数</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5688,33 +5668,33 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/monitor/toolmonitor_gui.ui" line="97"/>
         <source>Display options</source>
-        <translation>显示选项</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/monitor/toolmonitor_gui.ui" line="140"/>
         <source>Log scale</source>
-        <translation>对数刻度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/monitor/toolmonitor_gui.ui" line="162"/>
         <source>Legend</source>
-        <translation>图例</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/monitor/toolmonitor_gui.ui" line="221"/>
         <source>Default parameters</source>
-        <translation>默认参数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/monitor/toolmonitor_gui.ui" line="250"/>
         <source>Average value per key</source>
         <oldsource>Mean value per key</oldsource>
-        <translation>每个音符的平均值</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/monitor/toolmonitor_gui.ui" line="263"/>
         <source>Defined parameters</source>
-        <translation>定义的参数</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5722,12 +5702,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist.h" line="45"/>
         <source>Utility</source>
-        <translation>实用工具</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist.h" line="60"/>
         <source>Export preset list</source>
-        <translation>导出预设列表</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5735,27 +5715,27 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist_gui.ui" line="30"/>
         <source>Copy</source>
-        <translation>复制</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist_gui.ui" line="56"/>
         <source>text copied in the clipboard</source>
-        <translation>文本已复制到剪贴板</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist_gui.ui" line="81"/>
         <source>csv format</source>
-        <translation>CSV 表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist_gui.ui" line="91"/>
         <source>html table</source>
-        <translation>HTML 表</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/preset_list/toolpresetlist_gui.ui" line="113"/>
         <source>Close</source>
-        <translation>关闭</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5763,12 +5743,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/release/toolrelease.h" line="46"/>
         <source>Fast editing</source>
-        <translation>快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/release/toolrelease.h" line="61"/>
         <source>Natural release</source>
-        <translation>自然释音</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5781,22 +5761,22 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/release/toolrelease_gui.ui" line="38"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/release/toolrelease_gui.ui" line="67"/>
         <source>Division to the next octave</source>
-        <translation>划分到下个八度</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/release/toolrelease_gui.ui" line="110"/>
         <source>Detuning induced (semi-tones)</source>
-        <translation>引发失谐(半音)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/release/toolrelease_gui.cpp" line="51"/>
         <source>Release time (key %1)</source>
-        <translation>释音时长(音符 %1)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5805,23 +5785,24 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
         <source>%n modulator(s) has(have) been deleted.</source>
         <translation>
-            <numerusform>%n个调制器已被删除。</numerusform>
+            <numerusform>%n modulator has been deleted.</numerusform>
+            <numerusform>%n modulators have been deleted.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>
         <source>The selection contains no modulators.</source>
-        <translation>选择的对象不包含调制器。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.h" line="45"/>
         <source>Modulators</source>
-        <translation type="unfinished">调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.h" line="82"/>
         <source>Remove modulators</source>
-        <translation>移除调制器</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5829,17 +5810,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/sample_export/toolsampleexport.cpp" line="41"/>
         <source>Choose a destination folder</source>
-        <translation>选择目标文件夹</translation>
-    </message>
-    <message>
-        <location filename="editor/tools/sample_export/toolsampleexport.h" line="50"/>
-        <source>Files</source>
-        <translation>文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sample_export/toolsampleexport.h" line="68"/>
         <source>Wav export</source>
-        <translation>WAV导出</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/sample_export/toolsampleexport.h" line="50"/>
+        <source>Files</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5847,12 +5828,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization.h" line="45"/>
         <source>Fast editing</source>
-        <translation>快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization.h" line="63"/>
         <source>Sound spatialization</source>
-        <translation>声音空间化</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5860,37 +5841,37 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="138"/>
         <source>Inversions</source>
-        <translation>倒置</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="59"/>
         <source>Spreading (%)</source>
-        <translation>扩散(%)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="21"/>
         <source>Ascending</source>
-        <translation>上升</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="26"/>
         <source>Descending</source>
-        <translation>下降</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="31"/>
         <source>Hollow</source>
-        <translation>回荡</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="36"/>
         <source>Spike</source>
-        <translation>刺入</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="41"/>
         <source>Random</source>
-        <translation>随机</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="95"/>
@@ -5900,27 +5881,27 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="88"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="104"/>
         <source>Pattern</source>
-        <translation>模式</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="66"/>
         <source>Division number</source>
-        <translation>分割数</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="121"/>
         <source>Offset (0-100)</source>
-        <translation>偏移(0-100)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/sound_spatialization/toolsoundspatialization_gui.ui" line="181"/>
         <source>Filling (%)</source>
-        <translation>填充(%)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5928,22 +5909,22 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport.cpp" line="116"/>
         <source>Merge soudfonts:</source>
-        <translation>合并音色库：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport.cpp" line="211"/>
         <source>Export successful!</source>
-        <translation>导出成功！</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport.h" line="46"/>
         <source>Files</source>
-        <translation>文件</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport.h" line="61"/>
         <source>Export</source>
-        <translation>导出</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5951,74 +5932,74 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="22"/>
         <source>Select all</source>
-        <translation>全选</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="29"/>
         <source>Unselect all</source>
-        <translation>全不选</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="80"/>
         <source>Destination</source>
-        <translation>目标</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="106"/>
         <source>Format</source>
-        <translation>格式</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="116"/>
         <source>General MIDI classification</source>
-        <translation>GM MIDI 分类</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="123"/>
         <source>one directory per bank</source>
-        <translation>每个库置于单独文件夹</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="130"/>
         <source>preset number as prefix</source>
-        <translation>附加预设号前缀</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="141"/>
         <source>High</source>
-        <translation>高</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="146"/>
         <source>Medium</source>
-        <translation>中</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="151"/>
         <source>Low</source>
-        <translation>低</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="159"/>
         <source>Quality</source>
-        <translation>质量</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="190"/>
         <source>&amp;Cancel</source>
         <oldsource>Cancel</oldsource>
-        <translation type="unfinished">取消</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.ui" line="170"/>
         <source>&amp;Export</source>
         <oldsource>Export</oldsource>
-        <translation type="unfinished">导出</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="142"/>
         <source>Select the destination directory</source>
-        <translation>选择目标目录</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="158"/>
@@ -6026,27 +6007,27 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="193"/>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="202"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="158"/>
         <source>Invalid directory.</source>
-        <translation>路径不合法。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="187"/>
         <source>At least one preset must be selected.</source>
-        <translation>必须至少选择一个预设。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="193"/>
         <source>The maximal number of soundfont to export is 127.</source>
-        <translation>一次最多只能导出 127 个音色库。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/soundfont_export/toolsoundfontexport_gui.cpp" line="202"/>
         <source>In the case where several soundfonts are exported, the maximal number of presets per soundfonts is 127.</source>
-        <translation>导出音色库时，每个音色库的预设数不能超过 127。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6054,17 +6035,17 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/transpose/tooltranspose.cpp" line="159"/>
         <source>An instrument comprising no samples is not compatible with this tool:</source>
-        <translation>不含样本的乐器与该工具不兼容：</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/transpose/tooltranspose.h" line="45"/>
         <source>Fast editing</source>
-        <translation>快速编辑</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/transpose/tooltranspose.h" line="63"/>
         <source>Transpose</source>
-        <translation>变调</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6072,12 +6053,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/transpose_smpl/tooltransposesmpl.h" line="46"/>
         <source>Sample processing</source>
-        <translation>样本处理</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/transpose_smpl/tooltransposesmpl.h" line="61"/>
         <source>Transpose</source>
-        <translation>变调</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6085,7 +6066,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/transpose_smpl/tooltransposesmpl_gui.ui" line="20"/>
         <source>Shift in semitones</source>
-        <translation>移动量(半音)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/transpose_smpl/tooltransposesmpl_gui.ui" line="59"/>
@@ -6095,7 +6076,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/transpose_smpl/tooltransposesmpl_gui.ui" line="39"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6103,12 +6084,12 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/transpose/tooltranspose_gui.ui" line="20"/>
         <source>Shift in semitones</source>
-        <translation>移动量(半音)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/transpose/tooltranspose_gui.ui" line="27"/>
         <source>Adapt keyrange</source>
-        <translation>适应音符范围</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/transpose/tooltranspose_gui.ui" line="56"/>
@@ -6118,46 +6099,46 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tools/transpose/tooltranspose_gui.ui" line="36"/>
         <source>&amp;Ok</source>
-        <translation type="unfinished">确定(&amp;O)</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ToolTrimEnd</name>
     <message>
-        <location filename="editor/tools/trim_end/tooltrimend.h" line="46"/>
-        <source>Sample processing</source>
-        <translation>样本处理</translation>
-    </message>
-    <message>
         <location filename="editor/tools/trim_end/tooltrimend.h" line="64"/>
         <source>Trim to end of loop</source>
-        <translation>裁剪至循环终点</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/trim_end/tooltrimend.h" line="46"/>
+        <source>Sample processing</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ToolTrimStart</name>
     <message>
-        <location filename="editor/tools/trim_start/tooltrimstart.h" line="46"/>
-        <source>Sample processing</source>
-        <translation>样本处理</translation>
-    </message>
-    <message>
         <location filename="editor/tools/trim_start/tooltrimstart.h" line="64"/>
         <source>Remove blank at start</source>
-        <translation>移除开头空白</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/trim_start/tooltrimstart.h" line="46"/>
+        <source>Sample processing</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ToolUnlinkSample</name>
     <message>
-        <location filename="editor/tools/unlink_sample/toolunlinksample.h" line="49"/>
-        <source>Stereo samples</source>
-        <translation>双声道样本</translation>
-    </message>
-    <message>
         <location filename="editor/tools/unlink_sample/toolunlinksample.h" line="64"/>
         <source>Unlink</source>
-        <translation>取消链接</translation>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="editor/tools/unlink_sample/toolunlinksample.h" line="49"/>
+        <source>Stereo samples</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6165,32 +6146,32 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="mainwindow/toprightwidget.ui" line="74"/>
         <source>User area</source>
-        <translation>用户区</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/toprightwidget.ui" line="96"/>
         <source>Download status</source>
-        <translation>下载状态</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/toprightwidget.ui" line="118"/>
         <source>Main menu</source>
-        <translation>主菜单</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/toprightwidget.cpp" line="112"/>
         <source>Subscribe to a Premium account to get all the features!</source>
-        <translation>订阅高级账户获取所有功能!</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/toprightwidget.cpp" line="122"/>
         <source>Welcome %1</source>
-        <translation>欢迎 %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/toprightwidget.cpp" line="127"/>
         <source>Your account has been banned.</source>
-        <translation>你的账户已被封禁。</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6198,7 +6179,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tree/treeview.cpp" line="896"/>
         <source>instrument</source>
-        <translation>乐器</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeview.cpp" line="896"/>
@@ -6208,7 +6189,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tree/treeview.cpp" line="917"/>
         <source>Warning</source>
-        <translation type="unfinished">警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeview.cpp" line="917"/>
@@ -6221,32 +6202,32 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="48"/>
         <source>&amp;Bind to...</source>
-        <translation>绑定至(&amp;B)...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="53"/>
         <source>&amp;Replace by...</source>
-        <translation>替换为(&amp;R)...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="61"/>
         <source>&amp;Copy</source>
-        <translation>复制(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="67"/>
         <source>&amp;Paste</source>
-        <translation>粘贴(&amp;P)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="73"/>
         <source>D&amp;uplicate</source>
-        <translation>创建副本(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="79"/>
         <source>&amp;Delete</source>
-        <translation>删除(&amp;D)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="86"/>
@@ -6254,7 +6235,7 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tree/treeviewmenu.cpp" line="147"/>
         <source>Re&amp;name...</source>
         <oldsource>&amp;Rename...</oldsource>
-        <translation>重命名(&amp;R)...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="143"/>
@@ -6265,17 +6246,17 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tree/treeviewmenu.cpp" line="189"/>
         <location filename="editor/tree/treeviewmenu.cpp" line="192"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="190"/>
         <source>Cannot delete a sample used by another instrument.</source>
-        <translation>无法删除已被乐器使用的样本。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="193"/>
         <source>Cannot delete an instrument used by another preset.</source>
-        <translation>无法删除已被预设使用的乐器。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tree/treeviewmenu.cpp" line="340"/>
@@ -6305,12 +6286,12 @@ Other soundfont editors might display other units.</source>
         <location filename="repository/usermanager.cpp" line="144"/>
         <location filename="repository/usermanager.cpp" line="150"/>
         <source>Server error</source>
-        <translation>服务器错误</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="repository/usermanager.cpp" line="122"/>
         <source>Wrong username or password</source>
-        <translation>用户名或密码错误</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6319,12 +6300,12 @@ Other soundfont editors might display other units.</source>
         <location filename="editor/tools/waitingtooldialog.ui" line="50"/>
         <source>Processing...</source>
         <oldsource>Processing..</oldsource>
-        <translation>处理中...</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="editor/tools/waitingtooldialog.cpp" line="77"/>
         <source>Canceling...</source>
-        <translation>取消中...</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6332,7 +6313,7 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="mainwindow/widgetshowhistory.ui" line="90"/>
         <source>Empty list</source>
-        <translation>列表为空</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -6340,58 +6321,58 @@ Other soundfont editors might display other units.</source>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="89"/>
         <source>Settings</source>
-        <translation>设置</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="125"/>
         <source>Cannot open file &quot;%1&quot;</source>
-        <translation>无法打开文件 &quot;%1&quot;</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="183"/>
         <source>Online repository</source>
-        <translation>在线仓库</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="228"/>
         <source>Save before exiting?</source>
-        <translation>退出前是否保存文件？</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="231"/>
         <source>untitled</source>
-        <translation>未命名</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="232"/>
         <source>File &quot;%1&quot; has been modified.</source>
-        <translation>文件 &quot;%1&quot; 已被修改。</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="124"/>
         <location filename="mainwindow/windowmanager.cpp" line="233"/>
         <source>Warning</source>
-        <translation>警告</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="235"/>
         <source>&amp;Save</source>
-        <translation>保存(&amp;S)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="236"/>
         <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="237"/>
         <source>Do&amp;n&apos;t save</source>
-        <translation>不保存(&amp;N)</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow/windowmanager.cpp" line="325"/>
         <source>User area</source>
-        <translation>用户区</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/sources/polyphone_es.ts
+++ b/sources/polyphone_es.ts
@@ -2664,17 +2664,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 modulator:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 modulatores:</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n modulator:</numerusform>
+            <numerusform>%n modulatores:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2804,15 +2800,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>elementos</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>elemento</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementos</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3247,19 +3241,14 @@ de muestreo</translation>
         <comment>kilo byte</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5026,8 +5015,25 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5816,15 +5822,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 modulador ha sido eliminado.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>%1 moduladores han sido eliminado.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n modulador ha sido eliminado.</numerusform>
+            <numerusform>%n moduladores han sido eliminado.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_fr.ts
+++ b/sources/polyphone_fr.ts
@@ -2673,17 +2673,13 @@ mod. par défaut</translation>
         <source>Expand the modulator section</source>
         <translation>Afficher la section des modulateurs</translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 modulateur :</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 modulateurs :</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n modulateur :</numerusform>
+            <numerusform>%n modulateurs :</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2813,15 +2809,13 @@ mod. par défaut</translation>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>éléments</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>élément</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n élément</numerusform>
+            <numerusform>%n éléments</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3238,19 +3232,14 @@ d&apos;échantillonnage</translation>
         <comment>kilo byte</comment>
         <translation>ko</translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation>%1 (inutilisés : %2)</translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation>%1 (inutilisé : %2)</translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation>
+            <numerusform>%1 (inutilisé : %n)</numerusform>
+            <numerusform>%1 (inutilisés : %n)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5021,8 +5010,26 @@ D&apos;autres éditeurs de soundfonts pourraient utiliser d&apos;autres unités.
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
-        <translation>%1 échantillon(s) et %2 instrument(s) ont été supprimés.</translation>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
+        <translatorcomment>[X échantillon(s)] et [Y instrument(s)] ont été supprimés.</translatorcomment>
+        <translation>%1 et %2 ont été supprimés.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation>
+            <numerusform>%n échantillon</numerusform>
+            <numerusform>%n échantillons</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation>
+            <numerusform>%n instrument</numerusform>
+            <numerusform>%n instruments</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="69"/>
@@ -5811,15 +5818,13 @@ D&apos;autres éditeurs de soundfonts pourraient utiliser d&apos;autres unités.
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 modulateur a été supprimé.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>%1 modulateurs ont été supprimés.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n modulateur a été supprimé.</numerusform>
+            <numerusform>%n modulateurs ont été supprimés.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_it.ts
+++ b/sources/polyphone_it.ts
@@ -2661,17 +2661,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 modulatore:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 modulatori:</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n modulatore:</numerusform>
+            <numerusform>%n modulatori:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2801,15 +2797,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>elementi</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>elemento</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementi</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3244,19 +3238,14 @@ di campionamento</translation>
         <comment>kilo byte</comment>
         <translation>kB</translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation>%1 (inutilizzati: %2)</translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation>%1 (inutilizzati: %2)</translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation>
+            <numerusform>%1 (inutilizzati: %n)</numerusform>
+            <numerusform>%1 (inutilizzati: %n)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5024,8 +5013,26 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
-        <translation>%1 campione(i) e %2 strumento(i) sono stati cancellati.</translation>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
+        <translatorcomment>[X campione(i)] e [Y strumento(i)] sono stati cancellati.</translatorcomment>
+        <translation>%1 e %2 sono stati cancellati.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation>
+            <numerusform>%n campione</numerusform>
+            <numerusform>%n campioni</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation>
+            <numerusform>%n strumento</numerusform>
+            <numerusform>%n strumenti</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5814,15 +5821,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 modulatore è stato cancellato.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>%1 modulatori sono stati cancellati.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n modulatore è stato cancellato.</numerusform>
+            <numerusform>%n modulatori sono stati cancellati.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_ja.ts
+++ b/sources/polyphone_ja.ts
@@ -2659,17 +2659,12 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2799,15 +2794,12 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation type="unfinished"></translation>
+        <source>%n element(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3206,19 +3198,13 @@ rate</source>
         <comment>kilo byte</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -4983,8 +4969,23 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5773,15 +5774,12 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation type="unfinished"></translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_nl.ts
+++ b/sources/polyphone_nl.ts
@@ -2656,17 +2656,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2794,15 +2790,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation type="unfinished"></translation>
+        <source>%n element(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3201,19 +3195,14 @@ rate</source>
         <comment>kilo byte</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -4978,8 +4967,25 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5766,15 +5772,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation type="unfinished"></translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_pt.ts
+++ b/sources/polyphone_pt.ts
@@ -2664,17 +2664,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 modulador:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 moduladores:</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n modulador:</numerusform>
+            <numerusform>%n moduladores:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2804,15 +2800,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>elementos</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>elemento</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n elemento</numerusform>
+            <numerusform>%n elementos</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3250,19 +3244,14 @@ inválida</translation>
         <comment>kilo byte</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5029,8 +5018,25 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5819,15 +5825,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 modulador foi deletado.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>%1 moduladores foram deletados.</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>%n modulador foi deletado.</numerusform>
+            <numerusform>%n moduladores foram deletados.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_ru.ts
+++ b/sources/polyphone_ru.ts
@@ -2680,17 +2680,14 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation>Развернуть панель модуляторов</translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation>1 модулятор:</translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation>%1 модулятора(-ов):</translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation>
+            <numerusform>%n модулятор:</numerusform>
+            <numerusform>%n модулятора:</numerusform>
+            <numerusform>%n модуляторов:</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2819,15 +2816,14 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation>элементы</translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation>элемент</translation>
+        <source>%n element(s)</source>
+        <translation>
+            <numerusform>%n элемент</numerusform>
+            <numerusform>%n элемента</numerusform>
+            <numerusform>%n элементов</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3244,19 +3240,15 @@ rate</source>
         <comment>kilo byte</comment>
         <translation>КБ</translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation>%1 (не используются: %2)</translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation>%1 (не используется: %2)</translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation>
+            <numerusform>%1 (не используется: %n)</numerusform>
+            <numerusform>%1 (не используются: %n)</numerusform>
+            <numerusform>%1 (не используются: %n)</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5121,8 +5113,28 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
-        <translation>Были удалены %1 семпл(а,ов) и %2 инструмент(а,ов).</translation>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
+        <translatorcomment>Были удалены [X семпл(а,ов)] и [Y инструмент(а,ов)].</translatorcomment>
+        <translation>Были удалены %1 и %2.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation>
+            <numerusform>%n семпл</numerusform>
+            <numerusform>%n семпла</numerusform>
+            <numerusform>%n семплов</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation>
+            <numerusform>%n инструмент</numerusform>
+            <numerusform>%n инструмента</numerusform>
+            <numerusform>%n инструментов</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5908,15 +5920,14 @@ https://ru.wikipedia.org/wiki/Орган_(музыкальный_инструм�
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>Был удалён 1 модулятор.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation>Были удалены %1 модулятора(ов).</translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>Был удалён 1 модулятор.</numerusform>
+            <numerusform>Были удалены %1 модулятора.</numerusform>
+            <numerusform>Было удалено %1 модуляторов.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_sr.ts
+++ b/sources/polyphone_sr.ts
@@ -2660,17 +2660,14 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2800,15 +2797,14 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation type="unfinished"></translation>
+        <source>%n element(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3241,19 +3237,15 @@ rate</source>
         <comment>kilo byte</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -5018,8 +5010,27 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5808,15 +5819,14 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation>1 модулатор је уклоњен.</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation type="unfinished"></translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation>
+            <numerusform>Уклоњен је %n модулатор.</numerusform>
+            <numerusform>Уклоњена су %n модулатора.</numerusform>
+            <numerusform>Уклоњено %n модулатора.</numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>

--- a/sources/polyphone_tr.ts
+++ b/sources/polyphone_tr.ts
@@ -2656,17 +2656,13 @@ default mod.</source>
         <source>Expand the modulator section</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="256"/>
-        <source>1 modulator:</source>
-        <comment>singular form of modulator</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/modulator/modulatoreditor.cpp" line="258"/>
-        <source>%1 modulators:</source>
-        <comment>plural form of modulator</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/modulator/modulatoreditor.cpp" line="254"/>
+        <source>%n modulator(s):</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/modulator/modulatoreditor.cpp" line="344"/>
@@ -2794,15 +2790,13 @@ default mod.</source>
 </context>
 <context>
     <name>PageOverview</name>
-    <message>
+    <message numerus="yes">
         <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/overview/pageoverview.cpp" line="83"/>
-        <source>element</source>
-        <translation type="unfinished"></translation>
+        <source>%n element(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -3201,19 +3195,14 @@ rate</source>
         <comment>kilo byte</comment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="248"/>
-        <location filename="editor/pagesf2.cpp" line="261"/>
-        <source>%1 (unused: %2)</source>
-        <comment>plural form</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="editor/pagesf2.cpp" line="250"/>
-        <location filename="editor/pagesf2.cpp" line="263"/>
-        <source>%1 (unused: %2)</source>
-        <comment>singular form</comment>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <location filename="editor/pagesf2.cpp" line="247"/>
+        <location filename="editor/pagesf2.cpp" line="257"/>
+        <source>%1 (unused: %n)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -4978,8 +4967,25 @@ Other soundfont editors might display other units.</source>
     <name>ToolCleanUnused</name>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="110"/>
-        <source>%1 sample(s) and %2 instrument(s) have been deleted.</source>
+        <source>%1 and %2 have been deleted.</source>
+        <comment>[X sample(s)] and [Y instrument(s)] have been deleted.</comment>
         <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="111"/>
+        <source>%n sample(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="editor/tools/clean_unused_elements/toolcleanunused.cpp" line="112"/>
+        <source>%n instrument(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/clean_unused_elements/toolcleanunused.h" line="48"/>
@@ -5766,15 +5772,13 @@ Other soundfont editors might display other units.</source>
 </context>
 <context>
     <name>ToolRemoveMods</name>
-    <message>
-        <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="116"/>
-        <source>1 modulator has been deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="118"/>
-        <source>%1 modulators have been deleted.</source>
-        <translation type="unfinished"></translation>
+        <source>%n modulator(s) has(have) been deleted.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="editor/tools/remove_mods/toolremovemods.cpp" line="125"/>


### PR DESCRIPTION
Allow tr() to make own suggestions about plural forms in the destination
language.

For example, both English and French use simple rules to find out plurals, but
0 in English is plural, while in French it is singular. Moreover, for example,
Russian uses 3 forms:

1. for 1, 21, 31, ...
2. for 2-4, 22-24, ...
3. for 5-20, 25-30, ...

Combining all the 3 forms in one Russian word looks bulky and unprofessional
and hard to read.

Fortunately, the problems of i18n and localization have long been resolved
in Qt: https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals