### PR TITLE
Sanitize includes

### DIFF
--- a/sources/context/audiodevice.cpp
+++ b/sources/context/audiodevice.cpp
@@ -29,7 +29,7 @@
 #include "contextmanager.h"
 
 #ifndef Q_OS_WIN
-#include "jack.h"
+#include "jack/jack.h"
 
 // Jack callbacks
 int jackProcess(jack_nframes_t nframes, void * arg)

--- a/sources/polyphone.pro
+++ b/sources/polyphone.pro
@@ -68,8 +68,7 @@ unix:!macx {
     isEmpty(PREFIX) {
         PREFIX = /usr/local
     }
-    INCLUDEPATH += $$PREFIX/include/jack \
-        lib/flac
+    INCLUDEPATH += lib/flac
     DESTDIR=bin
     
     # Install target
@@ -145,7 +144,6 @@ contains(DEFINES, USE_LOCAL_STK) {
     INCLUDEPATH += lib/stk
 } else {
     LIBS += -lstk
-    INCLUDEPATH += $$PREFIX/include/stk
 }
 
 # Location of QCustomplot

--- a/sources/sound_engine/voice.h
+++ b/sources/sound_engine/voice.h
@@ -29,8 +29,8 @@
 #include "sound.h"
 #include "enveloppevol.h"
 #include "oscsinus.h"
-#include "Chorus.h"
-#include "FreeVerb.h"
+#include "stk/Chorus.h"
+#include "stk/FreeVerb.h"
 
 class Voice : public QObject
 {


### PR DESCRIPTION
This probably need work as I suspect it might need changes on the other platforms.

The rationale is as follow: both stk and jack header have to be included with the directory path. 
Using `$PREFIX/include/stk` and `$PREFIX/include/jack` is incorrect for two reason: they are not necessarily in prefix and as said above the director is part of the include name. At best `$PREFIX/include` is to be added (I actually think it's already there).

So the path on macos and windows might need to be adjusted.