### PR TITLE
Fix build with Qt >= 5.15

### DIFF
--- a/sources/editor/tree/treeitemdelegate.cpp
+++ b/sources/editor/tree/treeitemdelegate.cpp
@@ -24,6 +24,7 @@
 
 #include "treeitemdelegate.h"
 #include <QPainter>
+#include <QPainterPath>
 #include "treeview.h"
 #include "contextmanager.h"
 #include "basetypes.h"


### PR DESCRIPTION
Fixes:
| ../git/sources/editor/tree/treeitemdelegate.cpp:144:18: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>