### PR TITLE
Use different mime types

### DIFF
--- a/sources/contrib/polyphone.desktop
+++ b/sources/contrib/polyphone.desktop
@@ -15,4 +15,4 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Audio;Midi;Music;
 Keywords=sf2;sf3;sfz;sfArk;soundfonts;editor;instrument;audio;sound;sampler;
-MimeType=audio/x-soundfont;
+MimeType=audio/x-soundfont;audio/x-sfz;

--- a/sources/contrib/polyphone.xml
+++ b/sources/contrib/polyphone.xml
@@ -2,6 +2,8 @@
 <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
   <mime-type type="audio/x-soundfont">
     <comment>SoundFont</comment>
+    <comment xml:lang="ru">Файл SoundFont</comment>
+    <comment xml:lang="fr">Banque de son</comment>
   </mime-type>
 
   <mime-type type="audio/x-sf2">

--- a/sources/contrib/polyphone.xml
+++ b/sources/contrib/polyphone.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
   <mime-type type="audio/x-soundfont">
+    <comment>SoundFont</comment>
+  </mime-type>
+
+  <mime-type type="audio/x-sf2">
     <comment>SoundFont sf2</comment>
     <comment xml:lang="ru">Файл SoundFont sf2</comment>
     <comment xml:lang="fr">Banque de son sf2</comment>
@@ -10,23 +14,35 @@
       </match>
     </magic>
     <glob pattern="*.sf2"/>
+    <sub-class-of type="audio/x-soundfont"/>
   </mime-type>
-  <mime-type type="audio/x-soundfont">
-    <comment>SoundFont sfz</comment>
-    <comment xml:lang="ru">Файл SoundFont sfz</comment>
-    <comment xml:lang="fr">Banque de son sfz</comment>
-    <glob pattern="*.sfz"/>
-  </mime-type>
-  <mime-type type="audio/x-soundfont">
+
+  <mime-type type="audio/x-sf3">
     <comment>Compressed SoundFont sf3</comment>
     <comment xml:lang="ru">Сжатый файл SoundFont sf3</comment>
     <comment xml:lang="fr">Banque de son compressée sf3</comment>
+    <magic priority="50">
+      <match type="string" offset="0" value="RIFF">
+        <match type="string" offset="8" value="sfbk"/>
+      </match>
+    </magic>
     <glob pattern="*.sf3"/>
+    <sub-class-of type="audio/x-soundfont"/>
   </mime-type>
-  <mime-type type="audio/x-soundfont">
+
+  <mime-type type="audio/x-sfark">
     <comment>SoundFont archive sfArk</comment>
     <comment xml:lang="ru">Архив SoundFont sfArk</comment>
     <comment xml:lang="fr">Banque de son archivée sfArk</comment>
     <glob pattern="*.sfArk"/>
+    <sub-class-of type="audio/x-soundfont"/>
+  </mime-type>
+
+  <mime-type type="audio/x-sfz">
+    <comment>SoundFont sfz</comment>
+    <comment xml:lang="ru">Файл SoundFont sfz</comment>
+    <comment xml:lang="fr">Banque de son sfz</comment>
+    <glob pattern="*.sfz"/>
+    <sub-class-of type="text/plain"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
Proposed changes for #94.
@mirabilos hope this helps.

I noticed a wrong translation in the .desktop file, line 9 should be something like
`Comment[it]=Editor di soundfont`
I never heard using 'editore' in Italian for software editors, it sounds be a bit strange to me.

Also I kept the original sfz comment strings, but sfz is not a soundfont, it means "sforzando" in musical notation (hence the famous application used to open them) and it's a text file descriptor, not a monolithic audio font.

See <https://en.wikipedia.org/wiki/Dynamics_(music)#Sudden_changes_and_accented_notes>
