### PR TITLE
Switch from OpenSSL to WolfSSL for licence compatibility reasons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
     - libqcustomplot-dev
     - libvorbis-dev
     - libogg-dev
-    - libssl-dev
+    - libwolfssl-dev
     - libflac-dev
 script:
   - cd sources && qmake polyphone.pro QMAKE_CC=gcc-7 QMAKE_CXX=gcc-7 DEFINES+=USE_LOCAL_QCUSTOMPLOT PREFIX=/usr && make -j$(nproc)

--- a/sources/README
+++ b/sources/README
@@ -15,7 +15,7 @@ The following libraries are required (the name may vary depending on your system
  - qcustomplot (libqcustomplot-dev)
  - vorbis      (libvorbis-dev)
  - ogg         (libogg-dev)
- - ssl         (libssl-dev)
+ - wolfssl     (libwolfssl-dev)
  - flac        (libflac-dev)
 
 Use your package manager to install them: apt, synaptic, yum,...

--- a/sources/core/utils.cpp
+++ b/sources/core/utils.cpp
@@ -25,10 +25,16 @@
 #include "utils.h"
 #include <QStringList>
 #include <QFile>
-#include "openssl/rsa.h"
-#include "openssl/pem.h"
-#include "openssl/engine.h"
+#include <wolfssl/options.h>
+#include <wolfssl/openssl/rsa.h>
+#include <wolfssl/openssl/pem.h>
+#include <wolfssl/openssl/engine.h>
 #include "soundfontmanager.h"
+
+/* Debian #962149, fixed in libwolfssl-dev (>= 4.4.0+dfsg-4~) */
+#ifndef BIO_FLAGS_BASE64_NO_NL
+#define BIO_FLAGS_BASE64_NO_NL WOLFSSL_BIO_FLAG_BASE64_NO_NL
+#endif
 
 QString Utils::s_diacriticLetters;
 QStringList Utils::s_noDiacriticLetters;

--- a/sources/polyphone.pro
+++ b/sources/polyphone.pro
@@ -66,7 +66,7 @@ unix:!macx {
     QMAKE_CXXFLAGS += -std=c++11
     DEFINES += __LINUX_ALSASEQ__ __UNIX_JACK__
     CONFIG += link_pkgconfig
-    PKGCONFIG += alsa jack portaudio-2.0 zlib ogg flac vorbis vorbisfile vorbisenc glib-2.0 openssl
+    PKGCONFIG += alsa jack portaudio-2.0 zlib ogg flac vorbis vorbisfile vorbisenc glib-2.0 wolfssl
     isEmpty(PREFIX) {
         PREFIX = /usr/local
     }


### PR DESCRIPTION
(OpenSSL cannot be used in GPL’d projects without an exception)

Fixes https://github.com/davy7125/polyphone/issues/107