### PR TITLE
Allow building against the system copy of libsfark

### DIFF
--- a/sources/core/input/sfark/sfarkextractor2.cpp
+++ b/sources/core/input/sfark/sfarkextractor2.cpp
@@ -24,7 +24,6 @@
 
 #include "sfarkextractor2.h"
 #include "sfArkLib.h"
-#include "wcc.h"
 #include <QDebug>
 
 /////////////////////////////
@@ -92,7 +91,8 @@ int OutputFileHandle = -1;
 
 int ChkErr(const char *ErrorMsg, bool isInput)
 {
-    char ErrDesc[MAX_MSGTEXT];
+    char ErrDesc[SFARKLIB_MAX_MSGTEXT];
+    extern int GlobalErrorFlag;
 
     if (~GlobalErrorFlag)		// Prevent multiple error messages
     {
@@ -100,7 +100,7 @@ int ChkErr(const char *ErrorMsg, bool isInput)
             sprintf(ErrDesc, "Input: failed to %s", ErrorMsg);
         else
             sprintf(ErrDesc, "Output: failed to %s", ErrorMsg);
-        msg(ErrDesc, MSG_PopUp);
+        sfkl_msg(ErrDesc, SFARKLIB_MSG_PopUp);
         GlobalErrorFlag = SFARKLIB_ERR_FILEIO;
     }
 

--- a/sources/core/sample/samplereaderflac.cpp
+++ b/sources/core/sample/samplereaderflac.cpp
@@ -23,7 +23,7 @@
 ***************************************************************************/
 
 #include "samplereaderflac.h"
-#include "stream_decoder.h"
+#include "FLAC/stream_decoder.h"
 
 // https://xiph.org/flac/api/group__flac__stream__decoder.html
 

--- a/sources/core/sample/sound.cpp
+++ b/sources/core/sample/sound.cpp
@@ -31,7 +31,7 @@
 #include "qmath.h"
 #include <QFile>
 #include "contextmanager.h"
-#include "stream_decoder.h"
+#include "FLAC/stream_decoder.h"
 #include "sampleutils.h"
 #include "samplereader.h"
 #include "samplereaderfactory.h"

--- a/sources/polyphone.pro
+++ b/sources/polyphone.pro
@@ -10,6 +10,8 @@
 #DEFINES += USE_LOCAL_RTMIDI
 #DEFINES += USE_LOCAL_STK
 #DEFINES += USE_LOCAL_QCUSTOMPLOT
+# only works on x86:
+DEFINES += USE_LOCAL_SFARKLIB
 
 # Polyphone version
 DEFINES += SOFT_VERSION=\\\"2.2.0\\\"
@@ -946,39 +948,49 @@ RESOURCES += resources.qrc
 
 
 # SfArk extraction (what a mess!)
-DEFINES += __LITTLE_ENDIAN__
-INCLUDEPATH += lib/sfarklib
-HEADERS += lib/sfarklib/sfArkLib.h \
-    lib/sfarklib/wcc.h \
+HEADERS += \
     core/input/sfark/sfarkextractor2.h \
     core/input/sfark/abstractextractor.h
 
-SPECIAL_SOURCES = core/input/sfark/sfarkextractor1.cpp
-macx {
-    SOURCES += core/input/sfark/sfarkextractor2.cpp \
-        lib/sfarklib/sfklZip.cpp \
-        lib/sfarklib/sfklLPC.cpp \
-        lib/sfarklib/sfklDiff.cpp \
-        lib/sfarklib/sfklCrunch.cpp \
-        lib/sfarklib/sfklCoding.cpp
+contains(DEFINES, USE_LOCAL_SFARKLIB) {
+    DEFINES += __LITTLE_ENDIAN__
+    INCLUDEPATH += lib/sfarklib
+    HEADERS += lib/sfarklib/sfArkLib.h
+
+    SPECIAL_SOURCES = core/input/sfark/sfarkextractor1.cpp
+    macx {
+        SOURCES += core/input/sfark/sfarkextractor2.cpp \
+            lib/sfarklib/sfklZip.cpp \
+            lib/sfarklib/sfklLPC.cpp \
+            lib/sfarklib/sfklDiff.cpp \
+            lib/sfarklib/sfklCrunch.cpp \
+            lib/sfarklib/sfklCoding.cpp
+    } else {
+        SPECIAL_SOURCES += core/input/sfark/sfarkextractor2.cpp \
+            lib/sfarklib/sfklZip.cpp \
+            lib/sfarklib/sfklLPC.cpp \
+            lib/sfarklib/sfklDiff.cpp \
+            lib/sfarklib/sfklCrunch.cpp \
+            lib/sfarklib/sfklCoding.cpp
+    }
+    ExtraCompiler.input = SPECIAL_SOURCES
+    ExtraCompiler.variable_out = OBJECTS
+    ExtraCompiler.output = ${QMAKE_VAR_OBJECTS_DIR}${QMAKE_FILE_IN_BASE}$${QMAKE_EXT_OBJ}
+    win32 {
+        ExtraCompiler.commands = $${QMAKE_CXX} -D__LITTLE_ENDIAN__ -MD -arch:IA32 -D_CRT_SECURE_NO_WARNINGS $(INCPATH) -c ${QMAKE_FILE_IN} -Fo${QMAKE_FILE_OUT}
+    }
+    macx {
+        ExtraCompiler.commands = $${QMAKE_CXX} $(CXXFLAGS) -D__LITTLE_ENDIAN__ -mno-sse -mfpmath=387 $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
+    }
+    unix:!macx {
+        ExtraCompiler.commands = $${QMAKE_CXX} $(CXXFLAGS) -fPIC -D__LITTLE_ENDIAN__ -mfpmath=387 $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
+    }
+    QMAKE_EXTRA_COMPILERS += ExtraCompiler
 } else {
-    SPECIAL_SOURCES += core/input/sfark/sfarkextractor2.cpp \
-        lib/sfarklib/sfklZip.cpp \
-        lib/sfarklib/sfklLPC.cpp \
-        lib/sfarklib/sfklDiff.cpp \
-        lib/sfarklib/sfklCrunch.cpp \
-        lib/sfarklib/sfklCoding.cpp
+    # use system-wide copy instead
+    LIBS += -lsfark
+
+    SOURCES += \
+        core/input/sfark/sfarkextractor1.cpp \
+        core/input/sfark/sfarkextractor2.cpp
 }
-ExtraCompiler.input = SPECIAL_SOURCES
-ExtraCompiler.variable_out = OBJECTS
-ExtraCompiler.output = ${QMAKE_VAR_OBJECTS_DIR}${QMAKE_FILE_IN_BASE}$${QMAKE_EXT_OBJ}
-win32 {
-    ExtraCompiler.commands = $${QMAKE_CXX} -D__LITTLE_ENDIAN__ -MD -arch:IA32 -D_CRT_SECURE_NO_WARNINGS $(INCPATH) -c ${QMAKE_FILE_IN} -Fo${QMAKE_FILE_OUT}
-}
-macx {
-    ExtraCompiler.commands = $${QMAKE_CXX} $(CXXFLAGS) -D__LITTLE_ENDIAN__ -mno-sse -mfpmath=387 $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
-}
-unix:!macx {
-    ExtraCompiler.commands = $${QMAKE_CXX} $(CXXFLAGS) -fPIC -D__LITTLE_ENDIAN__ -mfpmath=387 $(INCPATH) -c ${QMAKE_FILE_IN} -o ${QMAKE_FILE_OUT}
-}
-QMAKE_EXTRA_COMPILERS += ExtraCompiler


### PR DESCRIPTION
This PR first changes a couple of source files to find the headers in their proper paths (similar to #100) and to not use `"wcc.h"` which is an sfarklib-internal header and never installed system-wide (pretty trivial changes, though).

I’ve only tested that for the system-wide scenario, though. Compare with #100 and see if the nōn-system-wide-sfarklib will need an extra `-I/path/to/FLAC/..` option.

Then, it changes the build instructions to add an option `USE_LOCAL_SFARKLIB`, which I leave enabled by default (so that this PR changes nothing by default), and if it’s not set, it uses the system-wide copy from Debian and drops the entire x86-specific (see #98), little-endian-specific, unportable, QMAKE_EXTRA_COMPILERS, ignoring packaging-provided CFLAGS, mess. (I’ve not changed that mess, just indented it one more level; use `git diff -w` or the equivalent GitHub option to ignore whitespace changes when reviewing it.)

I’ve only tested that in [this form](https://evolvis.org/plugins/scmgit/cgi-bin/gitweb.cgi?p=alioth/polyphone.git;a=blob;f=debian/patches/no-bundled.diff;hb=HEAD) and hope the one with the `USE_LOCAL_SFARKLIB` works; if not, please feel free to just fix it on top of my commits, or ping (@) me and I’ll have a go at it.

This change is mandatory for inclusion in distributions like Debian, and for building on most platforms / CPU architectures.