### PR TITLE
allow offset values greater than 16-bit signed integer

### DIFF
--- a/sources/core/types/attribute.cpp
+++ b/sources/core/types/attribute.cpp
@@ -181,11 +181,11 @@ AttributeValue Attribute::fromRealValue(AttributeType champ, bool isPrst, double
         break;
     case champ_startloopAddrsCoarseOffset: case champ_endloopAddrsCoarseOffset:
     case champ_startAddrsCoarseOffset: case champ_endAddrsCoarseOffset:
-        storedValue.shValue = Utils::round16(realValue) / 32768;
+        storedValue.shValue = static_cast<qint16>(qRound(realValue) / 32768);
         break;
     case champ_startloopAddrsOffset: case champ_startAddrsOffset:
     case champ_endloopAddrsOffset: case champ_endAddrsOffset:
-        storedValue.shValue = static_cast<qint16>(Utils::round16(realValue) % 32768);
+        storedValue.shValue = static_cast<qint16>(qRound(realValue) % 32768);
         break;
     case champ_keyRange: case champ_velRange:
         storedValue.rValue.byHi = static_cast<quint8>(0.001 * realValue);


### PR DESCRIPTION
A fix for issue #141, which was broken by commit f80fc38b406ad094a1d3d2563da5d8124818e2e3. This fix reverts to the use of qRound when storing offset values for sample and loop start/end.