### PR TITLE
fix for sustain and sostenuto pedal issues

### DIFF
--- a/sources/context/mididevice.cpp
+++ b/sources/context/mididevice.cpp
@@ -345,15 +345,18 @@ void MidiDevice::processControllerChanged(int channel, int numController, int va
     if (numController == 64)
     {
         // Sustain pedal
-        _isSustainOn = (value >= 64);
-        if (_isSustainOn)
+        if (value >= 64 && !_isSustainOn)
         {
+            _isSustainOn = true;
+            
             // All current keys are now sustained
             for (int key = 0; key < 128; key++)
                 _sustainedKeys[key] = _currentKeys[key] || _sostenutoMemoryKeys[key];
         }
-        else
+        else if (value < 64 && _isSustainOn)
         {
+            _isSustainOn = false;
+            
             // Remove all keys that have been previously sustained
             for (int key = 0; key < 128; key++)
             {
@@ -371,8 +374,10 @@ void MidiDevice::processControllerChanged(int channel, int numController, int va
     else if (numController == 66)
     {
         // Sostenuto pedal
-        if (value >= 64)
+        if (value < 64 && _isSostenutoOn)
         {
+            _isSostenutoOn = false;
+            
             // Remove all keys that have been held by the sostenuto pedal
             for (int key = 0; key < 128; key++)
             {
@@ -386,8 +391,10 @@ void MidiDevice::processControllerChanged(int channel, int numController, int va
                 }
             }
         }
-        else
+        else if (value >= 64 && !_isSostenutoOn)
         {
+            _isSostenutoOn = true;
+            
             // All current keys are now held by the sostenuto
             for (int key = 0; key < 128; key++)
                 _sostenutoMemoryKeys[key] = _currentKeys[key] || _sustainedKeys[key];

--- a/sources/context/mididevice.h
+++ b/sources/context/mididevice.h
@@ -110,7 +110,7 @@ private:
     bool _currentKeys[128];
     bool _sustainedKeys[128];
     bool _sostenutoMemoryKeys[128];
-    bool _isSustainOn;
+    bool _isSustainOn, _isSostenutoOn;
 };
 
 #endif // MIDIDEVICE_H


### PR DESCRIPTION
Fix for #186. Continuous-style foot pedals now work correctly and the sostenuto pedal's behavior is no longer inverted. Polyphone now only acts on CC64 or CC66 events if they trigger a change in status between "pedal on" or "pedal off", which avoids iterating through variables unnecessarily.