### PR TITLE
Fix Polish Translation

### DIFF
--- a/sources/polyphone_pl.ts
+++ b/sources/polyphone_pl.ts
@@ -311,12 +311,12 @@
     <message>
         <location filename="core/types/attribute.cpp" line="575"/>
         <source>Key → Vol env hold (c)</source>
-        <translation>klaw. → Utrzymanie obw. głośń. (c)</translation>
+        <translation>Klaw. → Utrzymanie obw. głośń. (c)</translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="578"/>
         <source>Key → Vol env decay (c)</source>
-        <translation>klaw. → Upadek obw. głośń. (c)</translation>
+        <translation>Klaw. → Upadek obw. głośń. (c)</translation>
     </message>
     <message>
         <location filename="core/types/attribute.cpp" line="581"/>
@@ -2949,7 +2949,7 @@ domyślnego mod.</translation>
     <message>
         <location filename="editor/pageenvelope.ui" line="181"/>
         <source>Key → Decay</source>
-        <translation>klaw. → Upadek</translation>
+        <translation>Klaw. → Upadek</translation>
     </message>
     <message>
         <location filename="editor/pageenvelope.ui" line="263"/>
@@ -2975,7 +2975,7 @@ domyślnego mod.</translation>
     <message>
         <location filename="editor/pageenvelope.ui" line="391"/>
         <source>Key → Hold</source>
-        <translation>klaw. → Przytrzymanie</translation>
+        <translation>Klaw. → Przytrzymanie</translation>
     </message>
     <message>
         <location filename="editor/pageenvelope.ui" line="420"/>


### PR DESCRIPTION
Hi,

I made a small mistake in my translation earlier: i translated "Chorus (%)" into the same value as "Reverb (%)" being "Pogłos (%)". I've fixed that now and I sincerely apologize.

And also since I couldn't get the exported `.qm` to load up in 2.4, I had to wait until a release with my locale in it, and most generator names are really long, which does not look good:
![image](https://github.com/user-attachments/assets/2942ce43-fca9-461f-8b4b-5ebbc03879e2)

So I've shortened them to make it look nicer. (English does that too, for example it's Vol Env Decay, not Volume Envelope Decay)