### PR TITLE
Correctly write dwLibrary, dwGenre, and dwMorphology fields

### DIFF
--- a/sources/core/output/sf2/outputsf2.cpp
+++ b/sources/core/output/sf2/outputsf2.cpp
@@ -639,13 +639,13 @@ void OutputSf2::save(QString fileName, SoundfontManager * sm, bool &success, QSt
 
         // dwLibrary
         dwTmp = sm->get(id, champ_dwLibrary).dwValue;
-        fi.write((char *)&wTmp, 4);
+        fi.write((char *)&dwTmp, 4);
         // dwGenre
         dwTmp = sm->get(id, champ_dwGenre).dwValue;
-        fi.write((char *)&wTmp, 4);
+        fi.write((char *)&dwTmp, 4);
         // dwMorphology
         dwTmp = sm->get(id, champ_dwMorphology).dwValue;
-        fi.write((char *)&wTmp, 4);
+        fi.write((char *)&dwTmp, 4);
     }
     // phdr de fin (38 byte)
     fi.write("EOP", 3);


### PR DESCRIPTION
When writing the dwLibrary, dwGenre, and dwMorphology fields, the code was erroneously passing a pointer to the wTmp variable (a quint16) instead of the dwTmp variable (a quint32), which held the correct values.

Although the write call requested 4 bytes, it was reading from the address of a 2-byte variable, leading to corrupted or incorrect data for these fields in the output file.