### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report a bug/incorrect behavior in Polyphone.
+
+labels: ["bug"]
+body:
+    - type: checkboxes
+      attributes:
+          label: Duplicated issue check
+          description: Please make sure that this issue has not been reported before.
+          options:
+              - label: I confirm that I have searched the existing issues.
+                required: true
+    - type: input
+      id: version
+      attributes:
+          label: version
+          description: The version of Polyphone you are using.
+      validations:
+          required: true
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: Describe the bug.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+        label: Offending SoundFont
+        description: If the bug is specific to a soundfont, zip it and upload it here.
+      validations:
+        required: false
+    - type: textarea
+      id: expected
+      attributes:
+          label: Expected Behavior
+          description: A concise description of what you expected to happen.
+      validations:
+          required: true
+    - type: textarea
+      id: reproduction
+      attributes:
+          label: Reproduction Steps
+          description: Steps to reproduce the behavior.
+          placeholder: |
+              1. Open Polyphone..
+              2. Load this soundfont
+              3. Click on '...'
+              4. See error...
+      validations:
+          required: true
+    - type: dropdown
+      id: os
+      attributes:
+          label: Operating System
+          description: Which operating system are you using?
+          options:
+              - Microsoft Windows
+              - Mac OS
+              - Fedora Linux
+              - Ubuntu Linux
+              - Other Linux (please specify which one)
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Additional Info
+          description: Any additional info and attachments go here.
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an idea for Polyphone!
+labels: ["enhancement"]
+body:
+    - type: textarea
+      id: problem
+      attributes:
+          label: Problem
+          description: Is your feature request related to a problem? Please describe.
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of what you want to happen.
+      validations:
+          required: true
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Alternatives
+          description: Describe alternatives you've considered. (if any)
+    - type: textarea
+      attributes:
+          label: Additional info
+          description: Any additional info and attachments (screenshots, soundfonts, other environments) go here.
+      validations:
+          required: false


### PR DESCRIPTION
Hi Davy,
This small PR adds the new **GitHub issue forms** to Polyphone's repo, making it easier for bug reporters to fill out information, and making certain fields required (feel free to change of course :-)

You can see how the GH forms look if you try to add an issue to spessasynth or fluidsynth.