### PR TITLE
Fix crash on startup when compiled with AVX

### DIFF
--- a/sources/core/fastmaths.cpp
+++ b/sources/core/fastmaths.cpp
@@ -86,9 +86,6 @@ float FastMaths::fastPow10(float value)
 
 void FastMaths::addVectors(float * __restrict a, const float * __restrict b, unsigned int size)
 {
-    a = (float*)__builtin_assume_aligned(a, 32);
-    b = (const float*)__builtin_assume_aligned(b, 32);
-
 #ifdef __aarch64__
     unsigned int i = 0;
     const unsigned int simdSize = size & ~15u; // 16 floats per loop
@@ -123,8 +120,6 @@ void FastMaths::addVectors(float * __restrict a, const float * __restrict b, uns
 
 void FastMaths::clamp(float * values, unsigned int size)
 {
-    values = (float*)__builtin_assume_aligned(values, 32);
-
 #ifdef __aarch64__
 
     const float32x4_t vmaxv = vdupq_n_f32(1.0f);
@@ -164,9 +159,6 @@ void FastMaths::clamp(float * values, unsigned int size)
 void FastMaths::multiplyAdd(float * __restrict data, const float * __restrict dataToMultiplyAndAdd,
                             unsigned int size, float coeff)
 {
-    data = (float*)__builtin_assume_aligned(data, 32);
-    dataToMultiplyAndAdd = (const float*)__builtin_assume_aligned(dataToMultiplyAndAdd, 32);
-
 #ifdef __aarch64__
 
     const float32x4_t vCoeff = vdupq_n_f32(coeff);
@@ -207,9 +199,6 @@ void FastMaths::multiplyAdd(float * __restrict data, const float * __restrict da
 
 void FastMaths::multiply(float * __restrict data, const float * __restrict dataToMultiply, unsigned int size, float coeff)
 {
-    data = (float*)__builtin_assume_aligned(data, 32);
-    dataToMultiply = (const float*)__builtin_assume_aligned(dataToMultiply, 32);
-
 #ifdef __aarch64__
     const float32x4_t vCoeff = vdupq_n_f32(coeff);
 
@@ -243,8 +232,6 @@ void FastMaths::multiply(float * __restrict data, const float * __restrict dataT
 
 float FastMaths::multiply8(const float * __restrict coeffs, const qint16 * __restrict srcData16, const quint8 * __restrict srcData24)
 {
-    coeffs  = (const float*)__builtin_assume_aligned(coeffs, 32);
-
 #ifdef __aarch64__
     // Load 8 int16 and convert to int32
     int16x8_t s16 = vld1q_s16(srcData16);
@@ -288,9 +275,6 @@ float FastMaths::multiply8(const float * __restrict coeffs, const qint16 * __res
 
 float FastMaths::multiply4(const float * __restrict coeffs, const float * __restrict srcDataF)
 {
-    coeffs = (const float*)__builtin_assume_aligned(coeffs, 32);
-    srcDataF = (const float*)__builtin_assume_aligned(srcDataF, 32);
-
 #ifdef __aarch64__
     // Load all values
     float32x4_t a = vld1q_f32(coeffs);


### PR DESCRIPTION
## Problem

Polyphone segfaults on startup (general-protection fault on the audio thread) when built with AVX enabled — e.g. `-march=native`, or any `-march` that turns on AVX. It's deterministic on source-based / optimized distributions (Gentoo, Arch with native flags, CachyOS…). Baseline builds (`-march=x86-64`, SSE only) are unaffected, which is why it hasn't shown up widely.

## Cause

The `FastMaths` helpers in `sources/core/fastmaths.cpp` promise the compiler 32-byte alignment via `__builtin_assume_aligned(ptr, 32)`, but the buffers passed in aren't guaranteed to be:

- engine buffers (`_dataL`, `_voiceData`, …) come from plain `new float[]` → only 16-byte aligned on x86-64;
- `SoundEngine::addData` runs `addVectors` on the sound-card output buffer, which the engine doesn't allocate;
- `multiply4`/`multiply8` get sinc-table coefficients at arbitrary offsets (`&sincWindow[frac * order + j]`), so `coeffs` can be 4-byte aligned.

With AVX, GCC trusts the promise and auto-vectorizes the generic loops (e.g. `addVectors`'s `a[i] += b[i]`) into aligned 256-bit moves (`vmovaps %ymm`). When a buffer isn't actually 32-byte aligned at runtime, that move raises a #GP. Confirmed from a core dump: faulting instruction `vmovaps (%rdi,%rax,1),%ymm0` with `rdi % 32 == 16`.

## Fix

Remove the unsafe alignment assumptions. Auto-vectorization still applies (unaligned moves cost the same as aligned ones on current x86), and the aarch64 NEON paths already use unaligned `vld1q_f32`, so they're unaffected.

Verified with `-march=alderlake`: Polyphone crashes immediately on launch before the change, and starts normally after.

If you'd rather keep aligned 256-bit AVX for the buffer-wide functions, the alternative is allocating the engine buffers 32-byte aligned (`operator new(…, std::align_val_t(32))`) — but that can't cover the sound-card output buffer or the sinc-table offsets, so dropping the assumption is the robust fix.
